### PR TITLE
feat(internal,controller,kubernetesupgrade,talosupgradae): set job la…

### DIFF
--- a/internal/controller/kubernetesupgrade_controller.go
+++ b/internal/controller/kubernetesupgrade_controller.go
@@ -489,6 +489,9 @@ func (r *KubernetesUpgradeReconciler) buildJob(ctx context.Context, kubernetesUp
 			ActiveDeadlineSeconds:   ptr.To(int64(KubernetesJobActiveDeadline)),
 			PodReplacementPolicy:    ptr.To(batchv1.Failed),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:                 corev1.RestartPolicyNever,
 					TerminationGracePeriodSeconds: ptr.To(int64(KubernetesJobGracePeriod)),

--- a/internal/controller/talosupgrade_controller.go
+++ b/internal/controller/talosupgrade_controller.go
@@ -838,6 +838,9 @@ func (r *TalosUpgradeReconciler) buildJob(ctx context.Context, talosUpgrade *tup
 			ActiveDeadlineSeconds:   ptr.To(getActiveDeadlineSeconds(timeout)),
 			PodReplacementPolicy:    ptr.To(batchv1.Failed),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:                 corev1.RestartPolicyNever,
 					TerminationGracePeriodSeconds: ptr.To(int64(TalosJobGracePeriod)),


### PR DESCRIPTION
…bels also as pod labels

This could be useful when specifying Network Policies for upgrade jobs.