### PR TITLE
fix(README): fix talos upgrade troubleshooting command

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ kubectl annotate kubernetesupgrade kubernetes tuppr.home-operations.com/suspend-
 
 ```bash
 # Reset failed Talos upgrade
-kubectl annotate talosupgrade cluster-upgrade tuppr.home-operations.com/reset="$(date)"
+kubectl annotate talosupgrade talos tuppr.home-operations.com/reset="$(date)"
 
 # Reset failed Kubernetes upgrade
 kubectl annotate kubernetesupgrade kubernetes tuppr.home-operations.com/reset="$(date)"


### PR DESCRIPTION
The `talosupgrade` resource is called `talos` (at least per v0.0.52) and not `cluster-upgrade` as per the README.