### PR TITLE
fix: allow repo without tags but not the other way around

### DIFF
--- a/internal/webhook/kubernetesupgrade_webhook.go
+++ b/internal/webhook/kubernetesupgrade_webhook.go
@@ -186,11 +186,11 @@ func (v *KubernetesUpgradeValidator) validateKubernetesSpec(kubernetes *tupprv1a
 	}
 
 	// Validate talosctl image if specified
-	talosctlRepoEmpty := kubernetes.Spec.Talosctl.Image.Repository == ""
-	talosctlTagEmpty := kubernetes.Spec.Talosctl.Image.Tag == ""
+	talosctlRepoEmpty := kubernetes.Spec.Talosctl.Image.Repository
+	talosctlTagEmpty := kubernetes.Spec.Talosctl.Image.Tag
 
-	if talosctlRepoEmpty != talosctlTagEmpty {
-		return fmt.Errorf("both spec.talosctl.image.repository and spec.talosctl.image.tag must be specified together, or both omitted for defaults")
+	if talosctlRepoEmpty == "" && talosctlTagEmpty != "" {
+		return fmt.Errorf("spec.talosctl.image.tag cannot be set without a repository")
 	}
 
 	// Validate pull policy if specified

--- a/internal/webhook/kubernetesupgrade_webhook_test.go
+++ b/internal/webhook/kubernetesupgrade_webhook_test.go
@@ -419,19 +419,6 @@ func TestKubernetesUpgrade_ValidateCreate_HealthCheckValidation(t *testing.T) {
 }
 
 func TestKubernetesUpgrade_ValidateCreate_TalosctlImagePartialSpec(t *testing.T) {
-	t.Run("repo without tag", func(t *testing.T) {
-		v := newK8sValidator(talosConfigSecret("default", validTalosConfig()))
-		ku := newKubernetesUpgrade("test", withK8sTalosctlImage("ghcr.io/custom/talosctl", ""))
-
-		_, err := v.ValidateCreate(context.Background(), ku)
-		if err == nil {
-			t.Fatal("expected error when repo set without tag")
-		}
-		if !strings.Contains(err.Error(), "must be specified together") {
-			t.Errorf("unexpected error message: %v", err)
-		}
-	})
-
 	t.Run("tag without repo", func(t *testing.T) {
 		v := newK8sValidator(talosConfigSecret("default", validTalosConfig()))
 		ku := newKubernetesUpgrade("test", withK8sTalosctlImage("", "v1.11.0"))

--- a/internal/webhook/talosupgrade_webhook.go
+++ b/internal/webhook/talosupgrade_webhook.go
@@ -160,11 +160,11 @@ func (v *TalosUpgradeValidator) validateTalosSpec(talos *tupprv1alpha1.TalosUpgr
 	}
 
 	// Validate talosctl image if specified
-	talosctlRepoEmpty := talos.Spec.Talosctl.Image.Repository == ""
-	talosctlTagEmpty := talos.Spec.Talosctl.Image.Tag == ""
+	talosctlRepoEmpty := talos.Spec.Talosctl.Image.Repository
+	talosctlTagEmpty := talos.Spec.Talosctl.Image.Tag
 
-	if talosctlRepoEmpty != talosctlTagEmpty {
-		return fmt.Errorf("both spec.talosctl.image.repository and spec.talosctl.image.tag must be specified together, or both omitted for defaults")
+	if talosctlRepoEmpty == "" && talosctlTagEmpty != "" {
+		return fmt.Errorf("spec.talosctl.image.tag cannot be set without a repository")
 	}
 
 	// Validate pull policy if specified

--- a/internal/webhook/talosupgrade_webhook_test.go
+++ b/internal/webhook/talosupgrade_webhook_test.go
@@ -430,19 +430,6 @@ func TestTalosUpgrade_ValidateCreate_HealthCheckValidation(t *testing.T) {
 // --- Talosctl image validation ---
 
 func TestTalosUpgrade_ValidateCreate_TalosctlImagePartialSpec(t *testing.T) {
-	t.Run("repo without tag", func(t *testing.T) {
-		v := newTalosValidator(talosConfigSecretWithKey("default", validTalosConfig()))
-		tu := newTalosUpgrade("test", withTalosTalosctlImage("ghcr.io/custom/talosctl", ""))
-
-		_, err := v.ValidateCreate(context.Background(), tu)
-		if err == nil {
-			t.Fatal("expected error when repo set without tag")
-		}
-		if !strings.Contains(err.Error(), "must be specified together") {
-			t.Errorf("unexpected error message: %v", err)
-		}
-	})
-
 	t.Run("tag without repo", func(t *testing.T) {
 		v := newTalosValidator(talosConfigSecretWithKey("default", validTalosConfig()))
 		tu := newTalosUpgrade("test", withTalosTalosctlImage("", "v1.11.0"))


### PR DESCRIPTION
we fetch the tag from the talos version if not set therefore we can allow it