### PR TITLE
chore(helm): support envs, volumes and volume mounts

### DIFF
--- a/charts/tuppr/templates/deployment.tpl
+++ b/charts/tuppr/templates/deployment.tpl
@@ -57,6 +57,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             {{- if .Values.webhook.enabled }}
             - name: webhook-server
@@ -85,6 +88,9 @@ spec:
             - name: talosconfig
               mountPath: /var/run/secrets/talos.dev
               readOnly: true
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         {{- if .Values.webhook.enabled }}
         - name: cert
@@ -96,6 +102,9 @@ spec:
           secret:
             secretName: {{ include "tuppr.serviceAccountName" . }}-talosconfig
             defaultMode: 420
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/tuppr/values.yaml
+++ b/charts/tuppr/values.yaml
@@ -57,6 +57,11 @@ podSecurityContext:
   runAsUser: 65532
   fsGroup: 65532
 
+# Additional environment variables passed to container
+env: []
+# - name: FOO
+#   value: bar
+
 # Container security context
 securityContext:
   allowPrivilegeEscalation: false
@@ -102,6 +107,19 @@ readinessProbe:
     port: 8081
   initialDelaySeconds: 5
   periodSeconds: 10
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
 
 # Node selector for pod assignment
 nodeSelector: {}


### PR DESCRIPTION
Now, that tuppr support validating talos images from remote sources, a new problem arises - support for custom talos factories with custom, self-signed certificates. Go can search in predefined paths for certificates, or use custom one via `SSL_CERT_*` variables (ref: https://stackoverflow.com/questions/40051213/where-is-golang-picking-up-root-cas-from ). This PR adds support for both volume/volumeMounts and custom envs, to support that.