### PR TITLE
fix(k8s-upgrade): reprocess partial update

### DIFF
--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -27,6 +27,9 @@ func createTestNode(name, ip string) *corev1.Node {
 					Status: corev1.ConditionTrue,
 				},
 			},
+			NodeInfo: corev1.NodeSystemInfo{
+				KubeletVersion: "v1.33.0",
+			},
 		},
 	}
 }


### PR DESCRIPTION
If an upgrade was interupted we assume what the node discovery is telling us but it only tell us the version for the VIP node, which might be correct, but all other controlplane have a different version