### PR TITLE
feat: e2e tests on hetzner cloud

### DIFF
--- a/test/e2e-hetzner/.mise.toml
+++ b/test/e2e-hetzner/.mise.toml
@@ -1,0 +1,7 @@
+[tools]
+kubectl = "1.35.1"
+talosctl = "1.12.4"
+helm = "4.1.1"
+stern = "1.33.1"
+jq = "1.8.1"
+opentofu = "1.11.4"

--- a/test/e2e-hetzner/README.md
+++ b/test/e2e-hetzner/README.md
@@ -1,0 +1,95 @@
+# Hetzner E2E Tests
+
+End-to-end tests for tuppr controller on Hetzner Cloud using OpenTofu and Bash.
+
+## Overview
+
+This test suite provisions a Talos Kubernetes cluster on Hetzner Cloud, deploys the tuppr controller, and validates both Talos and Kubernetes upgrade functionality with HA maintained via load balancer.
+
+## Quick Start
+
+### 1. Set Environment Variables
+
+**Required:**
+```bash
+export TF_VAR_hcloud_token="your-hetzner-token"
+```
+
+**Optional:**
+```bash
+export TF_VAR_run_id="custom-id"              # Default: $GITHUB_RUN_ID or "local"
+export TF_VAR_control_plane_count=3           # Default: 3
+export TF_VAR_worker_count=0                  # Default: 0
+export TF_VAR_talos_bootstrap_version=v1.11.0 # Default: v1.11.0
+export TF_VAR_k8s_bootstrap_version=v1.34.0   # Default: v1.34.0
+export CONTROLLER_IMAGE="custom-image:tag"    # Default: builds from source
+```
+
+### 2. Provision Infrastructure
+
+```bash
+cd tofu
+tofu init
+tofu apply
+```
+
+This creates:
+- Hetzner Cloud network
+- Server instances
+- Load balancer for Kubernetes API
+- Talos cluster with Cilium CNI
+- Kubeconfig and talosconfig in `/tmp/tuppr-e2e-{run_id}/`
+
+**Cluster naming:** `tuppr-e2e-{run_id}-{cp}cp-{w}w`
+- Example: `tuppr-e2e-local-3cp-0w` (local run, 3 control planes, 0 workers)
+- Example: `tuppr-e2e-1234567-1cp-2w` (GHA run #1234567, 1 control plane, 2 workers)
+
+### 3. Run Tests
+
+```bash
+cd ..
+./test.sh
+```
+
+The test script:
+1. Builds and pushes controller image (or uses `$CONTROLLER_IMAGE`)
+2. Waits for nodes Ready
+3. Installs tuppr with Helm
+5. Tests TalosUpgrade
+6. Tests KubernetesUpgrade
+
+### 4. Cleanup
+
+```bash
+cd tofu
+tofu destroy
+```
+
+## Variables Reference
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `hcloud_token` | string | (required) | Hetzner Cloud API token |
+| `run_id` | string | `"local"` | Unique run identifier |
+| `control_plane_count` | number | `3` | Number of control plane nodes (1-10) |
+| `worker_count` | number | `0` | Number of worker nodes (0-20) |
+| `talos_bootstrap_version` | string | `"v1.11.0"` | Initial Talos version |
+| `talos_upgrade_version` | string | `"v1.12.4"` | Target Talos version |
+| `k8s_bootstrap_version` | string | `"v1.34.0"` | Initial Kubernetes version |
+| `k8s_upgrade_version` | string | `"v1.35.0"` | Target Kubernetes version |
+| `server_type` | string | `"cx23"` | Hetzner server type |
+| `location` | string | `"nbg1"` | Hetzner datacenter location |
+| `config_dir` | string | `/tmp/tuppr-e2e-{run_id}` | Config file directory |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `kubeconfig_path` | Path to generated kubeconfig |
+| `talosconfig_path` | Path to generated talosconfig |
+| `talos_upgrade_version` | Target Talos version |
+| `k8s_upgrade_version` | Target Kubernetes version |
+| `cluster_name` | Generated cluster name |
+| `control_plane_ips` | Control plane node IPs |
+| `load_balancer_ip` | Load balancer IP |
+

--- a/test/e2e-hetzner/cr-templates/k8s-upgrade.yaml
+++ b/test/e2e-hetzner/cr-templates/k8s-upgrade.yaml
@@ -1,0 +1,7 @@
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: e2e-k8s-upgrade
+spec:
+  kubernetes:
+    version: ${K8S_TO_VERSION}

--- a/test/e2e-hetzner/cr-templates/talos-upgrade.yaml
+++ b/test/e2e-hetzner/cr-templates/talos-upgrade.yaml
@@ -1,0 +1,7 @@
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: e2e-talos-upgrade
+spec:
+  talos:
+    version: ${TALOS_TO_VERSION}

--- a/test/e2e-hetzner/test.sh
+++ b/test/e2e-hetzner/test.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/tofu"
+CR_TEMPLATES_DIR="${SCRIPT_DIR}/cr-templates"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+wait_for_cr_completed() {
+    local kind=$1
+    local name=$2
+    local timeout_seconds=$3
+    local deadline=$((SECONDS + timeout_seconds))
+
+    log "Waiting for $kind/$name to complete (timeout: ${timeout_seconds}s)..."
+    while [[ $SECONDS -lt $deadline ]]; do
+        local phase
+        phase=$(kubectl get "$kind" "$name" -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
+
+        log "$kind/$name phase: $phase"
+
+        if [[ "$phase" == "Completed" ]]; then
+            log "$kind/$name completed successfully"
+            return 0
+        fi
+
+        if [[ "$phase" == "Failed" ]]; then
+            log "ERROR: $kind/$name entered Failed phase"
+            kubectl get "$kind" "$name" -o yaml
+            return 1
+        fi
+
+        sleep 10
+    done
+
+    log "ERROR: Timeout waiting for $kind/$name to complete"
+    kubectl get "$kind" "$name" -o yaml
+    return 1
+}
+
+verify_talos_version() {
+    local expected_version=$1
+    log "Verifying all nodes are at Talos version $expected_version..."
+
+    # Get node IPs (talosconfig doesn't have nodes field set by module)
+    local node_ips
+    node_ips=$(kubectl get nodes -o json | jq -r '[.items[].status.addresses[] | select(.type=="ExternalIP") | .address] | join(",")')
+
+    local output
+    output=$(talosctl version --short --nodes "$node_ips" 2>&1)
+
+    local server_versions
+    server_versions=$(echo "$output" | grep "Tag:" | awk '{print $2}' | sort -u)
+
+    local version_count
+    version_count=$(echo "$server_versions" | wc -l)
+
+    if [[ $version_count -ne 1 ]]; then
+        log "ERROR: Found multiple Talos versions across nodes:"
+        echo "$output"
+        return 1
+    fi
+
+    if [[ "$server_versions" != "$expected_version" ]]; then
+        log "ERROR: Nodes are at $server_versions, expected $expected_version"
+        echo "$output"
+        return 1
+    fi
+
+    log "All nodes are at Talos version $expected_version"
+    return 0
+}
+
+verify_k8s_version() {
+    local expected_version=$1
+    log "Verifying all nodes are at Kubernetes version $expected_version..."
+
+    local nodes
+    nodes=$(kubectl get nodes -o json)
+
+    local node_count
+    node_count=$(echo "$nodes" | jq -r '.items | length')
+
+    for ((i=0; i<node_count; i++)); do
+        local node_name
+        node_name=$(echo "$nodes" | jq -r ".items[$i].metadata.name")
+        local kubelet_version
+        kubelet_version=$(echo "$nodes" | jq -r ".items[$i].status.nodeInfo.kubeletVersion")
+
+        if [[ "$kubelet_version" != "$expected_version" ]]; then
+            log "ERROR: Node $node_name kubelet is at $kubelet_version, expected $expected_version"
+            return 1
+        fi
+        log "Node $node_name kubelet: $kubelet_version"
+    done
+
+    log "All nodes are at Kubernetes version $expected_version"
+    return 0
+}
+
+main() {
+    cd "$TERRAFORM_DIR"
+
+    log "Reading Terraform outputs..."
+    KUBECONFIG=$(tofu output -raw kubeconfig_path)
+    TALOSCONFIG=$(tofu output -raw talosconfig_path)
+    TALOS_TO_VERSION=$(tofu output -raw talos_upgrade_version)
+    K8S_TO_VERSION=$(tofu output -raw k8s_upgrade_version)
+    EXPECTED_CLUSTER=$(tofu output -raw cluster_name)
+
+    log "Kubeconfig: $KUBECONFIG"
+    log "Talosconfig: $TALOSCONFIG"
+
+    # Safety checks before proceeding
+    if [[ "$KUBECONFIG" != /tmp/tuppr-e2e-* ]]; then
+        log "ERROR: Kubeconfig path '$KUBECONFIG' doesn't match expected pattern '/tmp/tuppr-e2e-*'"
+        log "       Refusing to proceed to avoid touching non-e2e clusters"
+        exit 1
+    fi
+
+    # Export after validation
+    export KUBECONFIG
+    export TALOSCONFIG
+
+    # Verify we're connected to the right cluster
+    local current_context
+    current_context=$(kubectl config current-context)
+    if [[ "$current_context" != admin@tuppr-e2e-* ]]; then
+        log "ERROR: Current context '$current_context' doesn't match expected pattern 'admin@tuppr-e2e-*'"
+        log "       Refusing to proceed to avoid touching non-e2e clusters"
+        exit 1
+    fi
+
+    # Verify node names match our cluster
+    local node_names
+    node_names=$(kubectl get nodes -o json | jq -r '.items[].metadata.name' | head -1)
+    if [[ "$node_names" != "$EXPECTED_CLUSTER"* ]]; then
+        log "ERROR: Node names don't start with '$EXPECTED_CLUSTER'"
+        log "       Found: $node_names"
+        log "       Refusing to proceed to avoid touching non-e2e clusters"
+        exit 1
+    fi
+
+    log "Connected to cluster: $EXPECTED_CLUSTER"
+    log "Target Talos version: $TALOS_TO_VERSION"
+    log "Target Kubernetes version: $K8S_TO_VERSION"
+
+    cd "$REPO_ROOT"
+
+    if [[ -n "${CONTROLLER_IMAGE:-}" ]]; then
+        log "Using pre-built controller image: $CONTROLLER_IMAGE"
+    else
+        log "Building controller image..."
+        RUN_ID=$(date +%s)
+        CONTROLLER_IMAGE="ttl.sh/tuppr-e2e-${RUN_ID}:2h"
+
+        docker build -t "$CONTROLLER_IMAGE" .
+        log "Pushing controller image..."
+        docker push "$CONTROLLER_IMAGE"
+        log "Controller image: $CONTROLLER_IMAGE"
+    fi
+
+    log "Waiting for cluster health checks..."
+    NODE_IP=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalIP") | .address')
+    talosctl --nodes $NODE_IP health --wait-timeout=10m
+
+    log "Generating CRDs..."
+    make helm-crds
+
+    log "Creating tuppr-system namespace..."
+    kubectl create namespace tuppr-system --dry-run=client -o yaml | kubectl apply -f -
+    kubectl label namespace tuppr-system \
+        pod-security.kubernetes.io/enforce=privileged \
+        pod-security.kubernetes.io/warn=privileged \
+        --overwrite
+
+    log "Installing tuppr via Helm..."
+    IFS=':' read -r REPO TAG <<< "$CONTROLLER_IMAGE"
+    helm upgrade --install tuppr "${REPO_ROOT}/charts/tuppr" \
+        --namespace tuppr-system \
+        --set image.repository="$REPO" \
+        --set image.tag="$TAG" \
+        --set image.pullPolicy=Always \
+        --set replicaCount=2 \
+        --wait \
+        --timeout 5m
+
+    log "Starting background monitoring..."
+    stern -n tuppr-system tuppr --since 1s 2>&1 | sed 's/^/[stern] /' &
+    STERN_PID=$!
+
+    kubectl get talosupgrade -w -o yaml 2>&1 | sed 's/^/[watch-talos] /' &
+    WATCH_TALOS_PID=$!
+
+    kubectl get kubernetesupgrade -w -o yaml 2>&1 | sed 's/^/[watch-k8s] /' &
+    WATCH_K8S_PID=$!
+
+    trap "kill $STERN_PID $WATCH_TALOS_PID $WATCH_K8S_PID 2>/dev/null || true" EXIT
+
+    log "============================================"
+    log "Starting TalosUpgrade test"
+    log "============================================"
+
+    log "Creating TalosUpgrade CR..."
+    export TALOS_TO_VERSION
+    envsubst < "${CR_TEMPLATES_DIR}/talos-upgrade.yaml" | kubectl apply -f -
+
+    wait_for_cr_completed talosupgrade e2e-talos-upgrade 1200
+    verify_talos_version "$TALOS_TO_VERSION"
+
+    log "============================================"
+    log "TalosUpgrade test PASSED"
+    log "============================================"
+
+    log "============================================"
+    log "Starting KubernetesUpgrade test"
+    log "============================================"
+
+    log "Creating KubernetesUpgrade CR..."
+    export K8S_TO_VERSION
+    envsubst < "${CR_TEMPLATES_DIR}/k8s-upgrade.yaml" | kubectl apply -f -
+
+    wait_for_cr_completed kubernetesupgrade e2e-k8s-upgrade 900
+    verify_k8s_version "$K8S_TO_VERSION"
+
+    log "============================================"
+    log "KubernetesUpgrade test PASSED"
+    log "============================================"
+
+    log "Stopping background monitoring..."
+    kill $STERN_PID $WATCH_TALOS_PID $WATCH_K8S_PID 2>/dev/null || true
+
+    log ""
+    log "=========================================="
+    log "ALL E2E TESTS PASSED"
+    log "=========================================="
+}
+
+main "$@"

--- a/test/e2e-hetzner/tofu/.gitignore
+++ b/test/e2e-hetzner/tofu/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfplan
+*.tfvars
+!example.tfvars

--- a/test/e2e-hetzner/tofu/loadbalancer.tf
+++ b/test/e2e-hetzner/tofu/loadbalancer.tf
@@ -1,0 +1,28 @@
+resource "hcloud_load_balancer" "kube_api" {
+  name               = "${local.cluster_name}-lb"
+  load_balancer_type = "lb11"
+  location           = var.location
+  labels             = local.common_labels
+}
+
+resource "hcloud_load_balancer_service" "kube_api" {
+  load_balancer_id = hcloud_load_balancer.kube_api.id
+  protocol         = "tcp"
+  listen_port      = 6443
+  destination_port = 6443
+
+  health_check {
+    protocol = "tcp"
+    port     = 6443
+    interval = 10
+    timeout  = 5
+    retries  = 3
+  }
+}
+
+resource "hcloud_load_balancer_target" "control_planes" {
+  type             = "label_selector"
+  load_balancer_id = hcloud_load_balancer.kube_api.id
+  label_selector   = "cluster=${local.cluster_name},role=control-plane"
+  use_private_ip   = false
+}

--- a/test/e2e-hetzner/tofu/main.tf
+++ b/test/e2e-hetzner/tofu/main.tf
@@ -1,0 +1,71 @@
+module "talos_cluster" {
+  source  = "hcloud-talos/talos/hcloud"
+  version = "3.1.1"
+
+  cluster_name   = local.cluster_name
+  cluster_prefix = true
+
+  talos_version      = var.talos_bootstrap_version
+  kubernetes_version = var.k8s_bootstrap_version
+
+  talos_iso_id_x86 = 122630
+  disable_arm = true
+
+  hcloud_token = var.hcloud_token
+
+  location_name = var.location
+
+  cluster_api_host           = hcloud_load_balancer.kube_api.ipv4
+  kubeconfig_endpoint_mode   = "public_endpoint"
+  talosconfig_endpoints_mode = "public_ip"
+
+  firewall_kube_api_source  = ["0.0.0.0/0"]
+  firewall_talos_api_source = ["0.0.0.0/0"]
+
+  enable_floating_ip = false
+
+  control_plane_nodes = [
+    for i in range(var.control_plane_count) : {
+      id   = i + 1
+      type = var.server_type
+    }
+  ]
+
+  worker_nodes = [
+    for i in range(var.worker_count) : {
+      id   = i + 1
+      type = var.server_type
+    }
+  ]
+
+  talos_control_plane_extra_config_patches = [
+    yamlencode({
+      machine = {
+        features = {
+          kubernetesTalosAPIAccess = {
+            enabled                     = true
+            allowedRoles                = ["os:admin"]
+            allowedKubernetesNamespaces = ["tuppr-system"]
+          }
+        }
+      }
+      cluster = {
+        controlPlane = {
+          endpoint = "https://${hcloud_load_balancer.kube_api.ipv4}:6443"
+        }
+      }
+    })
+  ]
+}
+
+resource "local_file" "kubeconfig" {
+  content         = module.talos_cluster.kubeconfig
+  filename        = "${local.config_dir}/kubeconfig"
+  file_permission = "0600"
+}
+
+resource "local_file" "talosconfig" {
+  content         = module.talos_cluster.talosconfig
+  filename        = "${local.config_dir}/talosconfig"
+  file_permission = "0600"
+}

--- a/test/e2e-hetzner/tofu/outputs.tf
+++ b/test/e2e-hetzner/tofu/outputs.tf
@@ -1,0 +1,34 @@
+output "kubeconfig_path" {
+  description = "Path to generated kubeconfig file"
+  value       = local_file.kubeconfig.filename
+}
+
+output "talosconfig_path" {
+  description = "Path to generated talosconfig file"
+  value       = local_file.talosconfig.filename
+}
+
+output "talos_upgrade_version" {
+  description = "Target Talos version for upgrade testing"
+  value       = var.talos_upgrade_version
+}
+
+output "k8s_upgrade_version" {
+  description = "Target Kubernetes version for upgrade testing"
+  value       = var.k8s_upgrade_version
+}
+
+output "cluster_name" {
+  description = "Generated cluster name"
+  value       = local.cluster_name
+}
+
+output "control_plane_ips" {
+  description = "Control plane node IP addresses"
+  value       = module.talos_cluster.public_ipv4_list
+}
+
+output "load_balancer_ip" {
+  description = "Load balancer IP address"
+  value       = hcloud_load_balancer.kube_api.ipv4
+}

--- a/test/e2e-hetzner/tofu/variables.tf
+++ b/test/e2e-hetzner/tofu/variables.tf
@@ -1,0 +1,88 @@
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token"
+  type        = string
+  sensitive   = true
+}
+
+variable "run_id" {
+  description = "Unique run identifier for resource naming and tracking. Auto-generated if not provided."
+  type        = string
+  default     = ""
+}
+
+variable "control_plane_count" {
+  description = "Number of control plane nodes"
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.control_plane_count >= 1 && var.control_plane_count <= 10
+    error_message = "Control plane count must be between 1 and 10"
+  }
+}
+
+variable "worker_count" {
+  description = "Number of worker nodes"
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.worker_count >= 0 && var.worker_count <= 20
+    error_message = "Worker count must be between 0 and 20"
+  }
+}
+
+variable "talos_bootstrap_version" {
+  description = "Initial Talos Linux version to deploy"
+  type        = string
+  default     = "v1.11.0"
+}
+
+variable "talos_upgrade_version" {
+  description = "Target Talos Linux version for upgrade testing"
+  type        = string
+  default     = "v1.12.4"
+}
+
+variable "k8s_bootstrap_version" {
+  description = "Initial Kubernetes version to deploy"
+  type        = string
+  default     = "v1.34.0"
+}
+
+variable "k8s_upgrade_version" {
+  description = "Target Kubernetes version for upgrade testing"
+  type        = string
+  default     = "v1.35.0"
+}
+
+variable "server_type" {
+  description = "Hetzner server type"
+  type        = string
+  default     = "cx23"
+}
+
+variable "location" {
+  description = "Hetzner datacenter location"
+  type        = string
+  default     = "nbg1"
+}
+
+variable "config_dir" {
+  description = "Directory for generated kubeconfig and talosconfig files. Auto-generated if not provided."
+  type        = string
+  default     = ""
+}
+
+locals {
+  run_id       = var.run_id != "" ? var.run_id : "local"
+  cluster_name = "tuppr-e2e-${local.run_id}-${var.control_plane_count}cp-${var.worker_count}w"
+  config_dir   = var.config_dir != "" ? var.config_dir : "/tmp/tuppr-e2e-${local.run_id}"
+
+  common_labels = {
+    managed-by          = "tuppr-e2e"
+    run-id              = local.run_id
+    control-plane-count = tostring(var.control_plane_count)
+    worker-count        = tostring(var.worker_count)
+  }
+}

--- a/test/e2e-hetzner/tofu/versions.tf
+++ b/test/e2e-hetzner/tofu/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.60"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = "~> 0.10"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.6"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}


### PR DESCRIPTION
This PR adds end to end tests running against ephemeral hetzner cloud VMs. It bootstraps 3 control plane nodes on talos v1.11.0, then does a TalosUpgrade to v1.12.4 and a KubernetesUpgrade to v1.35.0. The version numbers (and other elements) are of course parameterized.

To run, set the `TF_VAR_hcloud_token` env var to a hetzner API key, and then run:
* `cd tofu && tofu apply && cd ..`
* `./test.sh`
* `cd tofu && tofu destroy`

## Next steps

To be done in follow-up PRs:
* Run these tests in a github actions workflow
* Add more test cases:
1. Single controller with scheduling
2. Single controller, single worker
3. Three controllers, single worker

Potential future enhancements (that I'm not planning to do right now):
* Add a GHA cronjob that cleans up orphaned resources (though that shouldn't happen)