### PR TITLE
feat: gha workflow for Hetzner e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -20,6 +20,7 @@ jobs:
       TF_VAR_hcloud_token: ${{ secrets.HETZNER_API_TOKEN }}
       TF_VAR_control_plane_count: ${{ matrix.controllers }}
       TF_VAR_worker_count: ${{ matrix.workers }}
+      TF_VAR_run_id: ${{ github.run_id }}
     defaults:
       run:
         working-directory: test/e2e-hetzner

--- a/test/e2e-hetzner/README.md
+++ b/test/e2e-hetzner/README.md
@@ -17,7 +17,7 @@ export TF_VAR_hcloud_token="your-hetzner-token"
 
 **Optional:**
 ```bash
-export TF_VAR_run_id="custom-id"              # Default: $GITHUB_RUN_ID or "local"
+export TF_VAR_run_id="custom-id"              # Default: "local"
 export TF_VAR_control_plane_count=3           # Default: 3
 export TF_VAR_worker_count=0                  # Default: 0
 export TF_VAR_talos_bootstrap_version=v1.11.0 # Default: v1.11.0


### PR DESCRIPTION
Completed run: https://github.com/bo0tzz/tuppr/actions/runs/22197266496

Because it uses a secret, this workflow will fail on PRs from forks. If test runs on those are also wanted down the line, my suggestion would be to split the image building into a separate workflow, and then a `workflow_run` trigger after that to run the Hetzner tests with full permissions.