### PR TITLE
fix: error on talosctl version detection failure instead of falling back to latest

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -3,7 +3,6 @@ package constants
 // Default image constants
 const (
 	DefaultTalosctlImage = "ghcr.io/siderolabs/talosctl"
-	DefaultTalosctlTag   = "latest"
 )
 
 // Annotation keys

--- a/internal/controller/kubernetesupgrade/jobs_test.go
+++ b/internal/controller/kubernetesupgrade/jobs_test.go
@@ -19,7 +19,10 @@ func TestK8sBuildJob_Properties(t *testing.T) {
 		WithObjects(ku, newControllerNode(fakeCrtl, "10.0.0.1")).WithStatusSubresource(ku).Build()
 	r := newK8sReconciler(cl, &mockVersionGetter{}, tc, &mockHealthChecker{})
 
-	job := r.buildJob(context.Background(), ku, fakeCrtl, "10.0.0.1")
+	job, err := r.buildJob(context.Background(), ku, fakeCrtl, "10.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if job.Labels["app.kubernetes.io/name"] != "kubernetes-upgrade" {
 		t.Fatalf("expected kubernetes-upgrade label, got: %s", job.Labels["app.kubernetes.io/name"])
@@ -63,7 +66,10 @@ func TestK8sBuildJob_CustomImage(t *testing.T) {
 		WithObjects(ku, newControllerNode(fakeCrtl, "10.0.0.1")).WithStatusSubresource(ku).Build()
 	r := newK8sReconciler(cl, &mockVersionGetter{}, &mockTalosClient{}, &mockHealthChecker{})
 
-	job := r.buildJob(context.Background(), ku, fakeCrtl, "10.0.0.1")
+	job, err := r.buildJob(context.Background(), ku, fakeCrtl, "10.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	container := job.Spec.Template.Spec.Containers[0]
 	if container.Image != "my-registry.io/talosctl:v1.9.0" {
 		t.Fatalf("expected custom image, got: %s", container.Image)


### PR DESCRIPTION
`buildJob` now returns an error when version detection fails instead of silently falling back. The reconciler already handles this by setting the phase to `Failed` and requeuing after 1 minute — so the upgrade retries automatically once the Talos API is reachable again.

This aligns the Kubernetes upgrade controller with the Talos upgradecontroller, which already uses a meaningful fallback (the target Talos version) rather than `latest`.