### PR TITLE
fix: register cache index at startup for drain

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -173,13 +173,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "spec.nodeName", func(obj client.Object) []string {
-		pod, ok := obj.(*corev1.Pod)
-		if !ok || pod.Spec.NodeName == "" {
-			return nil
-		}
-		return []string{pod.Spec.NodeName}
-	}); err != nil {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&corev1.Pod{},
+		"spec.nodeName",
+		func(obj client.Object) []string {
+			pod, ok := obj.(*corev1.Pod)
+			if !ok || pod.Spec.NodeName == "" {
+				return nil
+			}
+			return []string{pod.Spec.NodeName}
+		},
+	); err != nil {
 		setupLog.Error(err, "unable to create index", "field", "Pod.spec.nodeName")
 		os.Exit(1)
 	}


### PR DESCRIPTION
This is following to the drain feature added in  https://github.com/home-operations/tuppr/commit/8dc798f51e42e1873501cdcdfe7e3b32c521458d

That change introduced a pod lookup by `spec.nodeName` in the drain. Without registering the field index first, drain was failing with
```
2026-02-22T20:42:31.648886189Z 2026-02-22T20:42:31Z ERROR Failed to drain node {"controller": "talosupgrade", "controllerGroup": "tuppr.home-operations.com", "controllerKind": "TalosUpgrade", "TalosUpgrade": {"name":"talos"}, "namespace": "", "name": "talos", "reconcileID": "2b1ff89a-8f9e-4bc4-a97c-89d3299a940a", "node": "minipc-01", "error": "failed to drain node minipc-01: failed to list pods: Index with name field:spec.nodeName does not exist"}
github.com/home-operations/tuppr/internal/controller/talosupgrade.(*Reconciler).processNextNode
    /workspace/internal/controller/talosupgrade/jobs.go:678
github.com/home-operations/tuppr/internal/controller/talosupgrade.(*Reconciler).processUpgrade
    /workspace/internal/controller/talosupgrade/controller.go:193
github.com/home-operations/tuppr/internal/controller/talosupgrade.(*Reconciler).Reconcile
    /workspace/internal/controller/talosupgrade/controller.go:101
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
    /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313
```

Tested the change on my cluster and it's now working fine.