### PR TITLE
feat(talosupgrade): allow customizing image factory URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Tuppr supports overriding the global TalosUpgrade configuration on a per-node ba
 | -------- | ------- | ------- |
 | tuppr.home-operations.com/version | Overrides the target Talos version for this node. | v1.12.1 |
 | tuppr.home-operations.com/schematic | Overrides the Talos schematic hash for this node. | b55fbf... |
+| tuppr.home-operations.com/factory-url | Overrides the image factory base used to build the installer image. Only applies when a schematic annotation is set. | factory.talos.dev/hcloud-installer |
 
 
 Example: Applying an override
@@ -276,6 +277,19 @@ kubectl annotate node worker-01 tuppr.home-operations.com/version="v1.12.1"
 
 # Apply a custom schematic (with specific extensions) to one node
 kubectl annotate node worker-02 tuppr.home-operations.com/schematic="314b18a3f89d..."
+
+# Use a non-default factory base (e.g., Hetzner Cloud installer flavor) for one node
+kubectl annotate node worker-03 tuppr.home-operations.com/factory-url="factory.talos.dev/hcloud-installer"
+```
+
+The factory base can also be set cluster-wide on the `TalosUpgrade` spec for use with the schematic annotation:
+
+```yaml
+spec:
+  talos:
+    version: v1.12.6
+    # Defaults to factory.talos.dev/installer when omitted
+    factoryURL: factory.talos.dev/hcloud-installer
 ```
 
 How it works:

--- a/api/v1alpha1/talosupgrade_types.go
+++ b/api/v1alpha1/talosupgrade_types.go
@@ -10,6 +10,14 @@ type TalosSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9\-\.]+)?$`
 	Version string `json:"version,omitempty"`
+
+	// FactoryURL overrides the Talos image factory base used when building the
+	// installer image from a schematic annotation. Must be a host[/path] without
+	// scheme or tag (e.g., "factory.talos.dev/installer", "factory.talos.dev/hcloud-installer").
+	// Defaults to "factory.talos.dev/installer" when unset.
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)+$`
+	// +optional
+	FactoryURL string `json:"factoryURL,omitempty"`
 }
 
 // Policy defines upgrade behavior options

--- a/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
@@ -249,6 +249,14 @@ spec:
               talos:
                 description: Talos specifies the talos configuration for upgrade operations
                 properties:
+                  factoryURL:
+                    description: |-
+                      FactoryURL overrides the Talos image factory base used when building the
+                      installer image from a schematic annotation. Must be a host[/path] without
+                      scheme or tag (e.g., "factory.talos.dev/installer", "factory.talos.dev/hcloud-installer").
+                      Defaults to "factory.talos.dev/installer" when unset.
+                    pattern: ^[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)+$
+                    type: string
                   version:
                     description: Version is the target Talos version to upgrade to
                       (e.g., "v1.11.0")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -13,8 +13,9 @@ const (
 
 const (
 	// Override annotations
-	SchematicAnnotation = "tuppr.home-operations.com/schematic"
-	VersionAnnotation   = "tuppr.home-operations.com/version"
+	SchematicAnnotation  = "tuppr.home-operations.com/schematic"
+	VersionAnnotation    = "tuppr.home-operations.com/version"
+	FactoryURLAnnotation = "tuppr.home-operations.com/factory-url"
 
 	// Default factory URL for schematic construction
 	DefaultFactoryURL = "factory.talos.dev/installer"

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -1857,6 +1857,75 @@ func TestTalosBuildTalosUpgradeImage(t *testing.T) {
 	}
 }
 
+func TestTalosBuildTalosUpgradeImage_SchematicAnnotation_DefaultFactory(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade("test-upgrade", withFinalizer)
+	tu.Spec.Talos.Version = fakeTalosVersion
+	node := newNode(fakeNodeA, "10.0.0.1")
+	node.Annotations = map[string]string{
+		constants.SchematicAnnotation: "abc123",
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, node).WithStatusSubresource(tu).Build()
+	r := newTalosReconciler(cl, scheme, &mockTalosClient{}, &mockHealthChecker{})
+
+	image, err := r.buildTalosUpgradeImage(context.Background(), tu, fakeNodeA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "factory.talos.dev/installer/abc123:" + fakeTalosVersion
+	if image != expected {
+		t.Fatalf("expected %s, got: %s", expected, image)
+	}
+}
+
+func TestTalosBuildTalosUpgradeImage_SchematicAnnotation_SpecFactoryURL(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade("test-upgrade", withFinalizer)
+	tu.Spec.Talos.Version = fakeTalosVersion
+	tu.Spec.Talos.FactoryURL = "factory.talos.dev/hcloud-installer"
+	node := newNode(fakeNodeA, "10.0.0.1")
+	node.Annotations = map[string]string{
+		constants.SchematicAnnotation: "abc123",
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, node).WithStatusSubresource(tu).Build()
+	r := newTalosReconciler(cl, scheme, &mockTalosClient{}, &mockHealthChecker{})
+
+	image, err := r.buildTalosUpgradeImage(context.Background(), tu, fakeNodeA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "factory.talos.dev/hcloud-installer/abc123:" + fakeTalosVersion
+	if image != expected {
+		t.Fatalf("expected %s, got: %s", expected, image)
+	}
+}
+
+func TestTalosBuildTalosUpgradeImage_SchematicAnnotation_AnnotationOverridesSpec(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade("test-upgrade", withFinalizer)
+	tu.Spec.Talos.Version = fakeTalosVersion
+	tu.Spec.Talos.FactoryURL = "factory.talos.dev/installer"
+	node := newNode(fakeNodeA, "10.0.0.1")
+	node.Annotations = map[string]string{
+		constants.SchematicAnnotation:  "abc123",
+		constants.FactoryURLAnnotation: "factory.talos.dev/hcloud-installer",
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, node).WithStatusSubresource(tu).Build()
+	r := newTalosReconciler(cl, scheme, &mockTalosClient{}, &mockHealthChecker{})
+
+	image, err := r.buildTalosUpgradeImage(context.Background(), tu, fakeNodeA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "factory.talos.dev/hcloud-installer/abc123:" + fakeTalosVersion
+	if image != expected {
+		t.Fatalf("expected %s, got: %s", expected, image)
+	}
+}
+
 func TestTalosBuildTalosUpgradeImage_InvalidFormat(t *testing.T) {
 	scheme := newTestScheme()
 	tu := newTalosUpgrade("test-upgrade", withFinalizer)

--- a/internal/controller/talosupgrade/upgrade.go
+++ b/internal/controller/talosupgrade/upgrade.go
@@ -486,8 +486,12 @@ func (r *Reconciler) buildTalosUpgradeImage(ctx context.Context, talosUpgrade *t
 	var imageBase string
 
 	if schematic, ok := node.Annotations[constants.SchematicAnnotation]; ok && schematic != "" {
-		imageBase = fmt.Sprintf("%s/%s", constants.DefaultFactoryURL, schematic)
-		logger.V(1).Info("Using schematic override from annotation", "node", nodeName, "schematic", schematic)
+		factoryURL := r.getFactoryURL(node, talosUpgrade.Spec.Talos.FactoryURL)
+		imageBase = fmt.Sprintf("%s/%s", factoryURL, schematic)
+		logger.V(1).Info("Using schematic override from annotation",
+			"node", nodeName,
+			"schematic", schematic,
+			"factoryURL", factoryURL)
 	} else {
 		nodeIP, err := nodeutil.GetNodeIP(node)
 		if err != nil {
@@ -521,6 +525,16 @@ func (r *Reconciler) getTargetVersion(node *corev1.Node, crdTargetVersion string
 		return v
 	}
 	return crdTargetVersion
+}
+
+func (r *Reconciler) getFactoryURL(node *corev1.Node, crdFactoryURL string) string {
+	if v, ok := node.Annotations[constants.FactoryURLAnnotation]; ok && v != "" {
+		return v
+	}
+	if crdFactoryURL != "" {
+		return crdFactoryURL
+	}
+	return constants.DefaultFactoryURL
 }
 
 func (r *Reconciler) verifyNodeUpgrade(ctx context.Context, talosUpgrade *tupprv1alpha1.TalosUpgrade, nodeName string) (bool, error) {

--- a/internal/webhook/talosupgrade/webhook.go
+++ b/internal/webhook/talosupgrade/webhook.go
@@ -75,6 +75,10 @@ func (v *Validator) validate(ctx context.Context, t *tupprv1alpha1.TalosUpgrade)
 		return warnings, fmt.Errorf("invalid talos version: %w", err)
 	}
 
+	if err := validation.ValidateFactoryURL(t.Spec.Talos.FactoryURL); err != nil {
+		return warnings, fmt.Errorf("invalid talos factoryURL: %w", err)
+	}
+
 	if err := validation.ValidateHealthChecks(t.Spec.HealthChecks); err != nil {
 		return warnings, err
 	}

--- a/internal/webhook/validation/validation.go
+++ b/internal/webhook/validation/validation.go
@@ -118,6 +118,23 @@ func ValidateVersionFormat(version string) error {
 	return nil
 }
 
+// ValidateFactoryURL checks the factory URL is a bare host[/path] reference
+// without a scheme or tag. Empty is valid (defaults are applied later).
+func ValidateFactoryURL(factoryURL string) error {
+	if factoryURL == "" {
+		return nil
+	}
+	pattern := `^[a-zA-Z0-9._-]+(:[0-9]+)?(/[a-zA-Z0-9._-]+)+$`
+	matched, err := regexp.MatchString(pattern, factoryURL)
+	if err != nil {
+		return fmt.Errorf("regex error: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("factoryURL '%s' invalid. Must be 'host[:port]/path' without scheme or tag (e.g., 'factory.talos.dev/installer')", factoryURL)
+	}
+	return nil
+}
+
 // ValidateSingleton ensures only one instance of the specific list type exists
 func ValidateSingleton(ctx context.Context, c client.Client, kindName, currentName string, list client.ObjectList) error {
 	if err := c.List(ctx, list); err != nil {

--- a/internal/webhook/validation/validation_test.go
+++ b/internal/webhook/validation/validation_test.go
@@ -328,6 +328,38 @@ func TestValidateVersionFormat(t *testing.T) {
 	}
 }
 
+func TestValidateFactoryURL(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name       string
+		factoryURL string
+		wantErr    bool
+	}{
+		{"empty (default applies)", "", false},
+		{"default factory", "factory.talos.dev/installer", false},
+		{"hcloud factory", "factory.talos.dev/hcloud-installer", false},
+		{"private registry with port", "registry.example.com:5000/installer", false},
+		{"nested path", "registry.example.com/team/installer", false},
+		{"with scheme rejected", "https://factory.talos.dev/installer", true},
+		{"with tag rejected", "factory.talos.dev/installer:v1.12.0", true},
+		{"trailing slash rejected", "factory.talos.dev/installer/", true},
+		{"no path rejected", "factory.talos.dev", true},
+		{"space rejected", "factory.talos.dev/foo bar", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFactoryURL(tt.factoryURL)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
 func TestValidateSingleton(t *testing.T) {
 	g := NewWithT(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- Adds `spec.talos.factoryURL` and `tuppr.home-operations.com/factory-url` node annotation to override the default `factory.talos.dev/installer` base when building installer images from a schematic.
- Resolution order: node annotation > spec field > existing `DefaultFactoryURL`. Backwards compatible — empty falls back to the current behavior.
- Enables platform-specific factory flavors (notably `factory.talos.dev/hcloud-installer` for Hetzner Cloud) that bake the correct `PlatformMetadata` into the image. Without this, hcloud nodes upgraded via the schematic-annotation path get rewritten to `platform: metal` because the factory base was hard-coded.

### Why

When the schematic annotation is set, [`buildTalosUpgradeImage`](https://github.com/home-operations/tuppr/blob/main/internal/controller/talosupgrade/upgrade.go) builds `factory.talos.dev/installer/<schematic>:<version>` unconditionally. For hcloud, the correct flavor is `hcloud-installer/<schematic>` — the regular `installer/...` produces `platform: metal` and breaks cloud-API metadata, hostname, and networking on next boot. The MachineConfig fallback path preserves whatever base is already installed, but that's not a usable workaround when nodes started life on the upstream `ghcr.io/siderolabs/installer` image.

### Changes

- `api/v1alpha1/talosupgrade_types.go`: new optional `FactoryURL` field on `TalosSpec` with kubebuilder validation pattern (`host[:port]/path`, no scheme, no tag).
- `internal/constants/constants.go`: new `FactoryURLAnnotation` constant.
- `internal/controller/talosupgrade/upgrade.go`: new `getFactoryURL` resolver and use of it in the schematic-annotation branch of `buildTalosUpgradeImage`. The MachineConfig fallback is unchanged (still preserves the existing base verbatim).
- `internal/webhook/validation/validation.go`: new `ValidateFactoryURL` helper rejecting schemes, tags, and trailing slashes.
- `internal/webhook/talosupgrade/webhook.go`: wires the new validation in.
- `config/crd/bases/...`: regenerated with `make manifests`.
- README: per-node annotation table and a short example for the spec-level field.

### Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched packages
- [x] Unit tests pass for `internal/webhook/validation`, `internal/controller/talosupgrade`, `internal/webhook/talosupgrade`
- [x] New unit tests:
  - `TestValidateFactoryURL` — empty, default, hcloud, private registry with port, nested path, scheme rejected, tag rejected, trailing slash rejected, no path rejected, space rejected
  - `TestTalosBuildTalosUpgradeImage_SchematicAnnotation_DefaultFactory` — unset spec keeps current behavior
  - `TestTalosBuildTalosUpgradeImage_SchematicAnnotation_SpecFactoryURL` — spec field is honored
  - `TestTalosBuildTalosUpgradeImage_SchematicAnnotation_AnnotationOverridesSpec` — annotation wins over spec
- [ ] Integration suite (`test/integration`) requires `kubebuilder` envtest binaries — not run locally; CI will exercise it.
- [ ] Manual smoke test on an hcloud cluster: set `factoryURL: factory.talos.dev/hcloud-installer` and the schematic annotation, confirm the resulting Job uses the hcloud-installer base.