### PR TITLE
feat(talosupgrade): fall back to extensions.talos.dev/schematic annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Tuppr supports overriding the global TalosUpgrade configuration on a per-node ba
 | tuppr.home-operations.com/version | Overrides the target Talos version for this node. | v1.12.1 |
 | tuppr.home-operations.com/schematic | Overrides the Talos schematic hash for this node. | b55fbf... |
 
+On Talos v1.8 and later, nodes automatically publish their schematic ID to the `extensions.talos.dev/schematic` annotation. Tuppr reads this annotation as a fallback, so the manual `tuppr.home-operations.com/schematic` annotation is only needed when you want to override the schematic Talos publishes (for example, to swap a node onto a different schematic).
 
 Example: Applying an override
 
@@ -274,13 +275,14 @@ Example: Applying an override
 # Upgrade a specific node to a different version than the global policy
 kubectl annotate node worker-01 tuppr.home-operations.com/version="v1.12.1"
 
-# Apply a custom schematic (with specific extensions) to one node
+# Override the schematic on a single node (e.g. swap it to a different one with extra extensions)
 kubectl annotate node worker-02 tuppr.home-operations.com/schematic="314b18a3f89d..."
 ```
 
 How it works:
 - The controller checks if a node version or schematic matches the annotation instead of the global TalosUpgrade spec.
-- If an inconsistency is found, an upgrade job is triggered for that node using the override values.
+- For the schematic, the tuppr override wins; otherwise the Talos-published `extensions.talos.dev/schematic` annotation is used; otherwise the schematic is parsed from the node's current install image.
+- If an inconsistency is found, an upgrade job is triggered for that node using the resolved values.
 
 ## ⚠️ Safe Talos Upgrade Paths
 
@@ -483,7 +485,7 @@ kubectl describe kubernetesupgrade kubernetes
 # View upgrade logs
 kubectl logs -f deployment/tuppr -n system-upgrade
 
-# Force a node to a specific version/schematic
+# Force a node to a specific version, or override the schematic Talos publishes
 kubectl annotate node <node-name> tuppr.home-operations.com/version="v1.10.7"
 kubectl annotate node <node-name> tuppr.home-operations.com/schematic="<hash>"
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -16,6 +16,9 @@ const (
 	SchematicAnnotation = "tuppr.home-operations.com/schematic"
 	VersionAnnotation   = "tuppr.home-operations.com/version"
 
+	// TalosSchematicAnnotation is published automatically by Talos >= v1.8.
+	TalosSchematicAnnotation = "extensions.talos.dev/schematic"
+
 	// Default factory URL for schematic construction
 	DefaultFactoryURL = "factory.talos.dev/installer"
 )

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -1775,6 +1775,48 @@ func TestNodeNeedsUpgrade(t *testing.T) {
 			},
 			wantError: true,
 		},
+		{
+			name:          "Schematic: Talos-published annotation matches current image -> No Upgrade",
+			nodeVersion:   "v1.12.0",
+			globalVersion: "v1.12.0",
+			nodeImage:     "factory.talos.dev/installer/talos-published-id:v1.12.0",
+			annotations: map[string]string{
+				constants.TalosSchematicAnnotation: "talos-published-id",
+			},
+			wantUpgrade: false,
+		},
+		{
+			name:          "Schematic: Talos-published annotation differs from current image -> Upgrade",
+			nodeVersion:   "v1.12.0",
+			globalVersion: "v1.12.0",
+			nodeImage:     "factory.talos.dev/installer/old-id:v1.12.0",
+			annotations: map[string]string{
+				constants.TalosSchematicAnnotation: "talos-published-id",
+			},
+			wantUpgrade: true,
+		},
+		{
+			name:          "Schematic: Both annotations set, tuppr override wins -> No Upgrade when image matches override",
+			nodeVersion:   "v1.12.0",
+			globalVersion: "v1.12.0",
+			nodeImage:     "factory.talos.dev/installer/tuppr-override-id:v1.12.0",
+			annotations: map[string]string{
+				constants.SchematicAnnotation:      "tuppr-override-id",
+				constants.TalosSchematicAnnotation: "talos-published-id",
+			},
+			wantUpgrade: false,
+		},
+		{
+			name:          "Schematic: Both annotations set, tuppr override wins -> Upgrade when image matches Talos value but not override",
+			nodeVersion:   "v1.12.0",
+			globalVersion: "v1.12.0",
+			nodeImage:     "factory.talos.dev/installer/talos-published-id:v1.12.0",
+			annotations: map[string]string{
+				constants.SchematicAnnotation:      "tuppr-override-id",
+				constants.TalosSchematicAnnotation: "talos-published-id",
+			},
+			wantUpgrade: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2236,6 +2278,68 @@ func TestTalosBuildTalosUpgradeImage_WithSchematicAnnotation(t *testing.T) {
 	expected := "factory.talos.dev/installer/abc123schematic:" + fakeTalosVersion
 	if image != expected {
 		t.Fatalf("expected schematic image %s, got: %s", expected, image)
+	}
+}
+
+func TestTalosBuildTalosUpgradeImage_WithTalosPublishedAnnotation(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade("test-upgrade", withFinalizer)
+	tu.Spec.Talos.Version = fakeTalosVersion
+
+	node := newNode(fakeNodeA, "10.0.0.1")
+	node.Annotations = map[string]string{
+		constants.TalosSchematicAnnotation: "talos-published-id",
+	}
+
+	// TalosClient should not be consulted for the install image when an annotation exists.
+	tc := &mockTalosClient{
+		getInstallErr: fmt.Errorf("GetNodeInstallImage should not be called"),
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, node).WithStatusSubresource(tu).Build()
+
+	r := newTalosReconciler(cl, scheme, tc, &mockHealthChecker{})
+
+	image, err := r.buildTalosUpgradeImage(context.Background(), tu, fakeNodeA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "factory.talos.dev/installer/talos-published-id:" + fakeTalosVersion
+	if image != expected {
+		t.Fatalf("expected schematic image %s, got: %s", expected, image)
+	}
+}
+
+func TestTalosBuildTalosUpgradeImage_TupprAnnotationOverridesTalos(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade("test-upgrade", withFinalizer)
+	tu.Spec.Talos.Version = fakeTalosVersion
+
+	node := newNode(fakeNodeA, "10.0.0.1")
+	node.Annotations = map[string]string{
+		constants.SchematicAnnotation:      "tuppr-override-id",
+		constants.TalosSchematicAnnotation: "talos-published-id",
+	}
+
+	tc := &mockTalosClient{
+		getInstallErr: fmt.Errorf("GetNodeInstallImage should not be called"),
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, node).WithStatusSubresource(tu).Build()
+
+	r := newTalosReconciler(cl, scheme, tc, &mockHealthChecker{})
+
+	image, err := r.buildTalosUpgradeImage(context.Background(), tu, fakeNodeA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "factory.talos.dev/installer/tuppr-override-id:" + fakeTalosVersion
+	if image != expected {
+		t.Fatalf("expected tuppr override to win, got: %s", image)
 	}
 }
 

--- a/internal/controller/talosupgrade/upgrade.go
+++ b/internal/controller/talosupgrade/upgrade.go
@@ -432,7 +432,7 @@ func (r *Reconciler) nodeNeedsUpgrade(ctx context.Context, node *corev1.Node, cr
 			"target", targetVersion)
 		return true, nil
 	}
-	if targetSchematic, ok := node.Annotations[constants.SchematicAnnotation]; ok && targetSchematic != "" {
+	if targetSchematic := resolveSchematic(node); targetSchematic != "" {
 		currentImage, err := r.TalosClient.GetNodeInstallImage(ctx, nodeIP)
 		if err != nil {
 			logger.Error(err, "Failed to get install image to verify schematic", "node", node.Name)
@@ -485,9 +485,9 @@ func (r *Reconciler) buildTalosUpgradeImage(ctx context.Context, talosUpgrade *t
 
 	var imageBase string
 
-	if schematic, ok := node.Annotations[constants.SchematicAnnotation]; ok && schematic != "" {
+	if schematic := resolveSchematic(node); schematic != "" {
 		imageBase = fmt.Sprintf("%s/%s", constants.DefaultFactoryURL, schematic)
-		logger.V(1).Info("Using schematic override from annotation", "node", nodeName, "schematic", schematic)
+		logger.V(1).Info("Using schematic from annotation", "node", nodeName, "schematic", schematic)
 	} else {
 		nodeIP, err := nodeutil.GetNodeIP(node)
 		if err != nil {
@@ -521,6 +521,19 @@ func (r *Reconciler) getTargetVersion(node *corev1.Node, crdTargetVersion string
 		return v
 	}
 	return crdTargetVersion
+}
+
+// resolveSchematic returns the schematic ID to target for this node, or "" if
+// neither the tuppr override nor the Talos-published annotation is present.
+// The tuppr annotation wins so users can override the value Talos publishes.
+func resolveSchematic(node *corev1.Node) string {
+	if v, ok := node.Annotations[constants.SchematicAnnotation]; ok && v != "" {
+		return v
+	}
+	if v, ok := node.Annotations[constants.TalosSchematicAnnotation]; ok && v != "" {
+		return v
+	}
+	return ""
 }
 
 func (r *Reconciler) verifyNodeUpgrade(ctx context.Context, talosUpgrade *tupprv1alpha1.TalosUpgrade, nodeName string) (bool, error) {


### PR DESCRIPTION
## Summary

- Since [Talos v1.8](https://www.talos.dev/v1.8/introduction/what-is-new/#talos-extensions-as-kubernetes-node-labelsannotations), nodes publish their schematic ID to the `extensions.talos.dev/schematic` annotation automatically. tuppr now reads it as a fallback, so users no longer need to manually `kubectl annotate` every node with `tuppr.home-operations.com/schematic` just to preserve the schematic across upgrades.
- The existing `tuppr.home-operations.com/schematic` annotation still takes precedence, so it remains usable as an explicit override (e.g. to swap a node onto a different schematic).
- Resolution order in [`upgrade.go`](https://github.com/home-operations/tuppr/blob/main/internal/controller/talosupgrade/upgrade.go): `tuppr.home-operations.com/schematic` → `extensions.talos.dev/schematic` → parse from the node's current install image (existing behavior, kept for pre-v1.8 nodes).

## Changes

- `internal/constants/constants.go` — add `TalosSchematicAnnotation` constant.
- `internal/controller/talosupgrade/upgrade.go` — new `resolveSchematic` helper that centralises the precedence; used in both `nodeNeedsUpgrade` and `buildTalosUpgradeImage`.
- `internal/controller/talosupgrade/controller_test.go` — extend `TestNodeNeedsUpgrade` with cases for the Talos-published annotation and override precedence; add two new tests for `buildTalosUpgradeImage` covering the same.
- `README.md` — clarify the new fallback behavior and that the manual annotation is now an override.

## Test plan

- [x] `make fmt vet` clean
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `go test ./internal/controller/talosupgrade/...` — all schematic tests pass
- [ ] Reviewer sanity check on a real Talos ≥ v1.8 cluster: a node with no `tuppr.home-operations.com/schematic` annotation but with the published `extensions.talos.dev/schematic` should produce an upgrade image of the form `factory.talos.dev/installer/<published-id>:<version>` (controller logs: `Using schematic from annotation`).