### PR TITLE
fix(kubernetesupgrade): inject hostAliases for controlPlaneEndpoint hostname

### DIFF
--- a/internal/controller/jobs/jobs.go
+++ b/internal/controller/jobs/jobs.go
@@ -29,6 +29,7 @@ type PodSpecOptions struct {
 	TalosConfigSecret string
 	GracePeriod       int64
 	Affinity          *corev1.Affinity
+	HostAliases       []corev1.HostAlias
 }
 
 // BuildTalosctlPodSpec returns the shared pod spec used by both upgrade controllers.
@@ -95,6 +96,10 @@ func BuildTalosctlPodSpec(opts PodSpecOptions) corev1.PodSpec {
 
 	if opts.Affinity != nil {
 		spec.Affinity = opts.Affinity
+	}
+
+	if len(opts.HostAliases) > 0 {
+		spec.HostAliases = opts.HostAliases
 	}
 
 	return spec

--- a/internal/controller/jobs/jobs_test.go
+++ b/internal/controller/jobs/jobs_test.go
@@ -133,6 +133,29 @@ func TestBuildTalosctlPodSpec_OptsApplied(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "host aliases empty when not provided",
+			opts: PodSpecOptions{},
+			check: func(t *testing.T, spec corev1.PodSpec) {
+				if len(spec.HostAliases) != 0 {
+					t.Errorf("want no HostAliases, got %v", spec.HostAliases)
+				}
+			},
+		},
+		{
+			name: "host aliases set when provided",
+			opts: PodSpecOptions{
+				HostAliases: []corev1.HostAlias{{IP: "10.0.1.100", Hostnames: []string{"kube.cluster.local"}}},
+			},
+			check: func(t *testing.T, spec corev1.PodSpec) {
+				if len(spec.HostAliases) != 1 ||
+					spec.HostAliases[0].IP != "10.0.1.100" ||
+					len(spec.HostAliases[0].Hostnames) != 1 ||
+					spec.HostAliases[0].Hostnames[0] != "kube.cluster.local" {
+					t.Errorf("HostAliases: got %v", spec.HostAliases)
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controller/kubernetesupgrade/controller.go
+++ b/internal/controller/kubernetesupgrade/controller.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"time"
 
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +37,7 @@ const (
 // TalosClient defines the interface for Talos operations
 type TalosClient interface {
 	GetNodeVersion(ctx context.Context, nodeIP string) (string, error)
+	GetNodeMachineConfig(ctx context.Context, nodeIP string) (*talosconfig.MachineConfig, error)
 }
 
 // HealthCheckRunner defines the interface for health checking

--- a/internal/controller/kubernetesupgrade/controller_test.go
+++ b/internal/controller/kubernetesupgrade/controller_test.go
@@ -10,6 +10,7 @@ import (
 	tupprv1alpha1 "github.com/home-operations/tuppr/api/v1alpha1"
 	"github.com/home-operations/tuppr/internal/constants"
 	"github.com/home-operations/tuppr/internal/metrics"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +29,10 @@ const (
 )
 
 type mockTalosClient struct {
-	nodeVersions  map[string]string
-	getVersionErr error
+	nodeVersions     map[string]string
+	getVersionErr    error
+	machineConfigs   map[string]*talosconfig.MachineConfig
+	getMachineCfgErr error
 }
 
 func (m *mockTalosClient) GetNodeVersion(ctx context.Context, nodeIP string) (string, error) {
@@ -40,6 +43,16 @@ func (m *mockTalosClient) GetNodeVersion(ctx context.Context, nodeIP string) (st
 		return v, nil
 	}
 	return "", fmt.Errorf("node %s not found", nodeIP)
+}
+
+func (m *mockTalosClient) GetNodeMachineConfig(ctx context.Context, nodeIP string) (*talosconfig.MachineConfig, error) {
+	if m.getMachineCfgErr != nil {
+		return nil, m.getMachineCfgErr
+	}
+	if mc, ok := m.machineConfigs[nodeIP]; ok {
+		return mc, nil
+	}
+	return nil, nil
 }
 
 type mockHealthChecker struct {

--- a/internal/controller/kubernetesupgrade/jobs.go
+++ b/internal/controller/kubernetesupgrade/jobs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/home-operations/tuppr/internal/controller/jobs"
 	"github.com/home-operations/tuppr/internal/controller/nodeutil"
 	"github.com/home-operations/tuppr/internal/metrics"
+	"github.com/home-operations/tuppr/internal/talos"
 )
 
 func (r *Reconciler) findActiveJob(ctx context.Context) (*batchv1.Job, error) {
@@ -190,11 +191,14 @@ func (r *Reconciler) buildJob(ctx context.Context, kubernetesUpgrade *tupprv1alp
 		pullPolicy = kubernetesUpgrade.Spec.Talosctl.Image.PullPolicy
 	}
 
+	hostAliases := r.resolveControlPlaneHostAliases(ctx, controllerNode, controllerIP)
+
 	logger.V(1).Info("Building Kubernetes upgrade job specification",
 		"controllerNode", controllerNode,
 		"talosctlImage", talosctlImage,
 		"pullPolicy", pullPolicy,
-		"args", args)
+		"args", args,
+		"hostAliases", hostAliases)
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -221,8 +225,41 @@ func (r *Reconciler) buildJob(ctx context.Context, kubernetesUpgrade *tupprv1alp
 					TalosConfigSecret: r.TalosConfigSecret,
 					GracePeriod:       KubernetesJobGracePeriod,
 					Affinity:          nil,
+					HostAliases:       hostAliases,
 				}),
 			},
 		},
 	}, nil
+}
+
+// resolveControlPlaneHostAliases reads the live machine config and, if cluster.controlPlaneEndpoint
+// is a hostname, returns a HostAlias mapping that hostname to the IP from extraHostEntries
+// (typically a VIP), or to the target node's IP as fallback. Returns nil when no alias is needed
+// or on any error — failure here must not block upgrades, since users with bespoke CoreDNS setups
+// already make the endpoint resolve through cluster DNS.
+func (r *Reconciler) resolveControlPlaneHostAliases(ctx context.Context, controllerNode, controllerIP string) []corev1.HostAlias {
+	logger := log.FromContext(ctx)
+
+	mc, err := r.TalosClient.GetNodeMachineConfig(ctx, controllerIP)
+	if err != nil {
+		logger.V(1).Info("Skipping controlPlaneEndpoint host-alias injection: failed to read machine config",
+			"node", controllerNode, "error", err.Error())
+		return nil
+	}
+	if mc == nil {
+		return nil
+	}
+
+	alias, err := talos.ResolveControlPlaneHostAlias(mc, controllerIP)
+	if err != nil {
+		logger.V(1).Info("Skipping controlPlaneEndpoint host-alias injection",
+			"node", controllerNode, "error", err.Error())
+		return nil
+	}
+	if alias == nil {
+		return nil
+	}
+	logger.V(1).Info("Injecting controlPlaneEndpoint host alias into upgrade pod",
+		"node", controllerNode, "ip", alias.IP, "hostnames", alias.Hostnames)
+	return []corev1.HostAlias{*alias}
 }

--- a/internal/talos/hostalias.go
+++ b/internal/talos/hostalias.go
@@ -1,0 +1,122 @@
+package talos
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/config/config"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ResolveControlPlaneHostAlias derives a HostAlias to inject into upgrade pods so that
+// `talosctl upgrade-k8s` can resolve cluster.controlPlaneEndpoint from inside the cluster.
+//
+// Returns nil if no alias is needed (endpoint is an IP literal, or the machine config doesn't
+// expose a usable endpoint). Returns a non-nil HostAlias when the endpoint is a hostname:
+//   - prefer an IP from a matching extraHostEntries / StaticHostConfig entry on the same machine config
+//   - otherwise fall back to fallbackIP (the target node IP, which always serves the apiserver)
+func ResolveControlPlaneHostAlias(mc *config.MachineConfig, fallbackIP string) (*corev1.HostAlias, error) {
+	if mc == nil {
+		return nil, fmt.Errorf("machine config is nil")
+	}
+
+	cfg := mc.Config()
+	if cfg == nil || cfg.Cluster() == nil {
+		return nil, nil
+	}
+
+	// cfg.Cluster().Endpoint() panics on a nil ControlPlane in the underlying v1alpha1
+	// struct, so isolate it via recover. Treating any failure here as "no alias needed"
+	// is the safe choice — we'd rather miss the optimization than break the upgrade.
+	endpoint := safeClusterEndpoint(cfg)
+	if endpoint == nil {
+		return nil, nil
+	}
+
+	host := endpointHost(endpoint)
+	if host == "" {
+		return nil, nil
+	}
+
+	// IP literal — pods can connect directly, no alias needed.
+	if net.ParseIP(host) != nil {
+		return nil, nil
+	}
+
+	// Look for a matching alias in the live machine config first.
+	if ip, hostnames := lookupStaticHost(mc, host); ip != "" {
+		return &corev1.HostAlias{IP: ip, Hostnames: hostnames}, nil
+	}
+
+	// Fall back to the target node's own IP. Every control-plane node serves the apiserver
+	// on :6443, and the apiserver cert covers the controlPlaneEndpoint hostname via certSANs.
+	if fallbackIP == "" {
+		return nil, nil
+	}
+	if net.ParseIP(fallbackIP) == nil {
+		return nil, fmt.Errorf("fallback IP %q is not a valid IP", fallbackIP)
+	}
+	return &corev1.HostAlias{IP: fallbackIP, Hostnames: []string{host}}, nil
+}
+
+// safeClusterEndpoint returns Cluster().Endpoint() but recovers from nil-deref panics
+// in the upstream v1alpha1 ClusterConfig.Endpoint when ControlPlane is unset.
+func safeClusterEndpoint(cfg talosconfig.Config) (u *url.URL) {
+	defer func() {
+		if r := recover(); r != nil {
+			u = nil
+		}
+	}()
+	return cfg.Cluster().Endpoint()
+}
+
+// endpointHost extracts the bare host from a controlPlaneEndpoint URL (no port).
+func endpointHost(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if h := u.Hostname(); h != "" {
+		return h
+	}
+	return u.Host
+}
+
+// lookupStaticHost finds a static-host entry whose aliases include `host`. It checks both
+// the legacy v1alpha1 machine.network.extraHostEntries and any StaticHostConfig documents
+// (the post-deprecation replacement). If found, it returns the entry's IP and the full
+// list of hostnames mapped to that IP, so all aliases are propagated to HostAlias.
+func lookupStaticHost(mc *config.MachineConfig, host string) (string, []string) {
+	// Legacy v1alpha1 extraHostEntries — still emitted by talhelper, hcloud-talos, etc.
+	if raw := mc.Provider().RawV1Alpha1(); raw != nil &&
+		raw.MachineConfig != nil && raw.MachineConfig.MachineNetwork != nil { //nolint:staticcheck // Need to read deprecated field for backward compatibility
+		for _, e := range raw.MachineConfig.MachineNetwork.ExtraHosts() { //nolint:staticcheck // Need to read deprecated field for backward compatibility
+			if matchesHost(e, host) {
+				return e.IP(), e.Aliases()
+			}
+		}
+	}
+
+	// New-style StaticHostConfig documents.
+	for _, doc := range mc.Provider().Documents() {
+		shc, ok := doc.(talosconfig.NetworkStaticHostConfig)
+		if !ok {
+			continue
+		}
+		if matchesHost(shc, host) {
+			return shc.IP(), shc.Aliases()
+		}
+	}
+
+	return "", nil
+}
+
+func matchesHost(e talosconfig.NetworkStaticHostConfig, host string) bool {
+	for _, alias := range e.Aliases() {
+		if alias == host {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/talos/hostalias_test.go
+++ b/internal/talos/hostalias_test.go
@@ -1,0 +1,175 @@
+package talos
+
+import (
+	"testing"
+
+	"github.com/siderolabs/talos/pkg/machinery/config/configloader"
+	"github.com/siderolabs/talos/pkg/machinery/resources/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadMachineConfig(t *testing.T, yaml string) *config.MachineConfig {
+	t.Helper()
+	provider, err := configloader.NewFromBytes([]byte(yaml))
+	require.NoError(t, err)
+	return config.NewMachineConfig(provider)
+}
+
+func TestResolveControlPlaneHostAlias_IPLiteral(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster:
+  controlPlane:
+    endpoint: https://10.0.0.10:6443
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	assert.Nil(t, alias, "no alias needed when controlPlaneEndpoint is an IP literal")
+}
+
+func TestResolveControlPlaneHostAlias_HostnameWithMatchingExtraHost(t *testing.T) {
+	cfg := `version: v1alpha1
+machine:
+  network:
+    extraHostEntries:
+      - ip: 10.0.1.100
+        aliases:
+          - kube.cluster.local
+cluster:
+  controlPlane:
+    endpoint: https://kube.cluster.local:6443
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	require.NotNil(t, alias)
+	assert.Equal(t, "10.0.1.100", alias.IP, "should pick up VIP from extraHostEntries")
+	assert.Equal(t, []string{"kube.cluster.local"}, alias.Hostnames)
+}
+
+func TestResolveControlPlaneHostAlias_HostnameNoMatch_FallbackToNodeIP(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster:
+  controlPlane:
+    endpoint: https://kube.example.internal:6443
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	require.NotNil(t, alias)
+	assert.Equal(t, "10.0.1.101", alias.IP, "should fall back to target node IP")
+	assert.Equal(t, []string{"kube.example.internal"}, alias.Hostnames)
+}
+
+func TestResolveControlPlaneHostAlias_MultipleAliasesPropagated(t *testing.T) {
+	cfg := `version: v1alpha1
+machine:
+  network:
+    extraHostEntries:
+      - ip: 10.0.1.100
+        aliases:
+          - kube.cluster.local
+          - api.cluster.local
+          - cluster-vip
+cluster:
+  controlPlane:
+    endpoint: https://kube.cluster.local:6443
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	require.NotNil(t, alias)
+	assert.Equal(t, "10.0.1.100", alias.IP)
+	assert.Equal(t, []string{"kube.cluster.local", "api.cluster.local", "cluster-vip"}, alias.Hostnames,
+		"all aliases on the matching extraHostEntries IP should be propagated")
+}
+
+func TestResolveControlPlaneHostAlias_StaticHostConfigDocument(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster:
+  controlPlane:
+    endpoint: https://kube.cluster.local:6443
+---
+apiVersion: v1alpha1
+kind: StaticHostConfig
+name: 10.0.1.100
+hostnames:
+  - kube.cluster.local
+  - api.cluster.local
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	require.NotNil(t, alias)
+	assert.Equal(t, "10.0.1.100", alias.IP, "should pick up IP from StaticHostConfig document")
+	assert.ElementsMatch(t, []string{"kube.cluster.local", "api.cluster.local"}, alias.Hostnames)
+}
+
+func TestResolveControlPlaneHostAlias_NoEndpoint(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster: {}
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	assert.Nil(t, alias, "no alias when controlPlaneEndpoint is unset")
+}
+
+func TestResolveControlPlaneHostAlias_NilMachineConfig(t *testing.T) {
+	alias, err := ResolveControlPlaneHostAlias(nil, "10.0.1.101")
+	require.Error(t, err)
+	assert.Nil(t, alias)
+}
+
+func TestResolveControlPlaneHostAlias_InvalidFallbackIP(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster:
+  controlPlane:
+    endpoint: https://kube.example.internal:6443
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "not-an-ip")
+	require.Error(t, err)
+	assert.Nil(t, alias)
+}
+
+func TestResolveControlPlaneHostAlias_EmptyFallbackIP(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster:
+  controlPlane:
+    endpoint: https://kube.example.internal:6443
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "")
+	require.NoError(t, err)
+	assert.Nil(t, alias, "no alias when fallback IP is empty and no extraHostEntry matches")
+}
+
+func TestResolveControlPlaneHostAlias_IPv6Literal(t *testing.T) {
+	cfg := `version: v1alpha1
+machine: {}
+cluster:
+  controlPlane:
+    endpoint: "https://[fd00::1]:6443"
+`
+	mc := loadMachineConfig(t, cfg)
+
+	alias, err := ResolveControlPlaneHostAlias(mc, "10.0.1.101")
+	require.NoError(t, err)
+	assert.Nil(t, alias, "no alias needed for IPv6 literal endpoint")
+}

--- a/test/integration/mocks_test.go
+++ b/test/integration/mocks_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	tupprv1alpha1 "github.com/home-operations/tuppr/api/v1alpha1"
+	talosconfig "github.com/siderolabs/talos/pkg/machinery/resources/config"
 )
 
 // mockTalosClient implements TalosClient interface for testing
@@ -67,6 +68,10 @@ func (m *mockTalosClient) PatchNodeInstallImage(ctx context.Context, nodeIP, new
 	defer m.mu.Unlock()
 	m.installImages[nodeIP] = newImage
 	return nil
+}
+
+func (m *mockTalosClient) GetNodeMachineConfig(ctx context.Context, nodeIP string) (*talosconfig.MachineConfig, error) {
+	return nil, nil
 }
 
 func (m *mockTalosClient) Reset() {


### PR DESCRIPTION
## Summary

`KubernetesUpgrade` jobs run `talosctl upgrade-k8s`, which connects to `cluster.controlPlane.endpoint` to detect the lowest running Kubernetes version across control-plane pods. On clusters where that endpoint is a hostname resolved on Talos hosts only (typically a VIP via `machine.network.extraHostEntries` mapping `kube.cluster.local` → VIP), the upgrade pod's default `ClusterFirst` DNS cannot resolve it and the job fails immediately with:

```
error detecting the lowest Kubernetes version Get
\"https://kube.cluster.local:6443/api/v1/namespaces/kube-system/pods\":
dial tcp: lookup kube.cluster.local on 10.0.8.10:53: no such host
```

This affects clusters provisioned with the standard hcloud-talos / talhelper / official Talos quickstart VIP+hostname setup — i.e. most production HA Talos clusters.

### Fix

When building the upgrade Job, read the live machine config (already available via the existing Talos client) and:
1. Parse the host out of `cluster.controlPlane.endpoint`.
2. If it's a hostname (not an IP literal), look up the matching IP from `extraHostEntries` / `StaticHostConfig` documents on the same machine config — this is the same source of truth Talos itself uses for the host's `/etc/hosts`.
3. If no match, fall back to the target node's own IP — every control-plane node serves the apiserver on `:6443` and the apiserver cert covers the endpoint hostname via `certSANs`.
4. Inject the result as `PodSpec.HostAliases`. IP-literal endpoints get no alias (current behavior preserved).

This is per-Job, doesn't change cluster DNS, doesn't require `hostNetwork`, and is the minimal safe fix. Failures in alias resolution log at V(1) and return nil — the upgrade is never blocked.

### Changes

- `internal/talos/hostalias.go` — new `ResolveControlPlaneHostAlias` helper.
- `internal/controller/jobs/jobs.go` — add `HostAliases` to `PodSpecOptions`, propagate to `PodSpec.HostAliases`.
- `internal/controller/kubernetesupgrade/controller.go` — extend `TalosClient` interface with `GetNodeMachineConfig`.
- `internal/controller/kubernetesupgrade/jobs.go` — call resolver from `buildJob`, pass result through.

## Test plan

Unit tests in `internal/talos/hostalias_test.go` cover:

- [x] IP-literal endpoint → no alias injected
- [x] Hostname endpoint with matching `extraHostEntries` → alias with VIP
- [x] Hostname endpoint with no match → alias with target node IP fallback
- [x] Multiple aliases on one IP → all propagated
- [x] New-style `StaticHostConfig` document → picked up alongside legacy `extraHostEntries`
- [x] No endpoint / nil machine config / empty fallback IP → no alias, no panic
- [x] Invalid fallback IP → error returned (caller logs and skips)
- [x] IPv6 literal endpoint → no alias

Plus updated `jobs_test.go` cases for the new `HostAliases` field on `PodSpecOptions`.

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./internal/...` passes

End-to-end validation against a Hetzner-cloud cluster with `kube.cluster.local` → VIP setup is the next step (the original failure mode is loud, so this should be straightforward to confirm).

## Out of scope

- Optional CRD field `spec.kubernetes.hostAliases` as an explicit escape hatch (Option B in the bug report) — not implemented; can be a follow-up if the autodiscovery isn't sufficient for some edge cases.
- README / chart docs updates.
- Upstream `talosctl upgrade-k8s` fallback to `--endpoints` — Sidero change, not tuppr.
- Pre-flight DNS check before scheduling the Job.