### PR TITLE
fix(ci): release helm job needs controller-gen from mise

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,10 +131,10 @@ jobs:
         with:
           version: v3.19.0
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Install Mise and required tools
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
+          cache_key: "mise-v1-{{file_hash}}"
 
       - name: Generate manifests and CRDs
         run: make helm-crds


### PR DESCRIPTION
## Overview

Since switching to mise for all dependencies in https://github.com/home-operations/tuppr/commit/ecdcc52ed78915f5f30344b71cb79a97678e65d0, the release action has been broken. No helm charts have been released since 0.1.21. This is because the release workflow wasn't updated to use mise to install controller-gen.

## Additional information

The release workflow is very similar to the build workflow. The build workflow was updated correctly in https://github.com/home-operations/tuppr/commit/088df70926b74d39ca6c9bf17ac7706d41a1f71b. It looks like the release workflow was just missed.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/tuppr/blob/main/CONTRIBUTING.md). I have read and agreed.
- AI usage disclosure: No AI was used.
