### PR TITLE
ci: restore helm chart publishing via dedicated workflow

### DIFF
--- a/.github/workflows/chartreleaser.yaml
+++ b/.github/workflows/chartreleaser.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  helm:
+    name: Helm
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    env:
+      VERSION: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          cache: false
+          experimental: true
+          install_args: --locked
+
+      - name: Generate manifests and CRDs
+        run: mise run helm-crds
+
+      - name: Package Helm chart
+        run: |
+          helm package charts/tuppr \
+            --version "${VERSION}" \
+            --app-version "${VERSION}"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Helm chart to GHCR
+        run: |-
+          helm push "tuppr-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"


### PR DESCRIPTION
The helm chart-publish job was dropped when `release.yaml` migrated to the `docker/github-builder` reusable workflow (#301), so **releases since then have not published a chart**. This restores it as a standalone, release-triggered workflow — mirroring the `goreleaser.yaml` split that keeps `release.yaml` uniform across repos.

Faithful to the original job:
- `mise-action --locked` provides the pinned `helm` 4.2.0 + `controller-gen` (no runner dependency).
- `mise run helm-crds` regenerates CRDs into the chart.
- `helm package charts/tuppr` at the release tag (`--version`/`--app-version`), then `helm push` to `oci://ghcr.io/<owner>/charts`.

The only change vs the original is sourcing the version from the release tag directly (the old job read it from the now-removed `merge` job's metadata output). Tags are bare semver (`include-v-in-tag: false`), so it matches the image tag.

Validated with `zizmor` and `actionlint`.

> Release-triggered, so it can't run on this PR — first exercised on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
