### PR TITLE
ci: make the helm-unittest plugin version renovatable

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+  HELM_UNITTEST_VERSION: "v1.0.3"
+
 jobs:
   test:
     name: Go Tests
@@ -75,7 +79,7 @@ jobs:
 
       - name: Run helm unit tests
         run: |-
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3 --verify=false
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
           mise run helm-test
 
       - name: Check chart docs are current


### PR DESCRIPTION
Pins the helm-unittest plugin version in a workflow-level `env:` annotated with the github-releases datasource, so Renovate bumps it like any other dependency instead of it sitting stale as a hardcoded `--version v1.0.3` flag.

```yaml
env:
  # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
  HELM_UNITTEST_VERSION: "v1.0.3"
```

The install step references `${HELM_UNITTEST_VERSION}` (shell env, not `${{ }}`, so no template-injection surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)