### PR TITLE
feat(talos): Add NoDrain to talos policy

### DIFF
--- a/api/v1alpha1/talosupgrade_types.go
+++ b/api/v1alpha1/talosupgrade_types.go
@@ -25,6 +25,11 @@ type PolicySpec struct {
 	// +optional
 	Force bool `json:"force,omitempty"`
 
+	// NoDrain disables drain for the upgrade.
+	// +kubebuilder:default=false
+	// +optional
+	NoDrain bool `json:"nodrain,omitempty"`
+
 	// Placement controls how strictly upgrade jobs avoid the target node
 	// hard: required avoidance (job will fail if can't avoid target node)
 	// soft: preferred avoidance (job prefers to avoid but can run on target node)
@@ -163,7 +168,8 @@ type TalosUpgradeSpec struct {
 	// +optional
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
 
-	// Drain configuration for the node prior to upgrade
+	// Drain configuration for the node prior to upgrade.
+	// Deprecated: Use Talos policy drain configuration instead.
 	// +optional
 	Drain *DrainSpec `json:"drain,omitempty"`
 

--- a/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
@@ -68,7 +68,9 @@ spec:
             description: TalosUpgradeSpec defines the desired state of TalosUpgrade
             properties:
               drain:
-                description: Drain configuration for the node prior to upgrade
+                description: |-
+                  Drain configuration for the node prior to upgrade.
+                  Deprecated: Use Talos policy drain configuration instead.
                 properties:
                   disableEviction:
                     description: DisableEviction forces drain to use delete, even
@@ -4788,6 +4790,10 @@ spec:
                     default: false
                     description: Force the upgrade (skip checks on etcd health and
                       members)
+                    type: boolean
+                  nodrain:
+                    default: false
+                    description: NoDrain disables drain for the upgrade.
                     type: boolean
                   placement:
                     default: soft

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -1787,6 +1787,7 @@ func TestTalosBuildJob_Properties(t *testing.T) {
 	tu.Spec.Talos.Version = fakeTalosVersion
 	tu.Spec.Policy.Placement = "hard"
 	tu.Spec.Policy.Debug = true
+	tu.Spec.Policy.NoDrain = true
 	tu.Spec.Policy.Force = true
 	tu.Spec.Policy.RebootMode = "powercycle"
 	tu.Spec.Policy.Stage = true
@@ -1831,6 +1832,7 @@ func TestTalosBuildJob_Properties(t *testing.T) {
 
 	wantArgs := map[string]bool{
 		"--debug=true":               false,
+		"--drain=false":              false,
 		"--force=true":               false,
 		"--reboot-mode=powercycle":   false,
 		"--stage":                    false,

--- a/internal/controller/talosupgrade/jobs.go
+++ b/internal/controller/talosupgrade/jobs.go
@@ -490,13 +490,14 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 		waitArg,
 	)
 
-	if selfHosted {
-		args = append(args, "--drain=false")
-	}
-
 	if talosUpgrade.Spec.Policy.Debug {
 		args = append(args, "--debug=true")
 		logger.V(1).Info("Debug upgrade enabled", "node", nodeName)
+	}
+
+	if selfHosted || talosUpgrade.Spec.Policy.NoDrain {
+		args = append(args, "--drain=false")
+		logger.V(1).Info("Upgrade drain disabled", "node", nodeName)
 	}
 
 	if talosUpgrade.Spec.Policy.Force {


### PR DESCRIPTION
## Overview

talosctl 1.13 added client-side node drain enabled by default to the upgrade command. Because it is enabled by default, the policy flag is NoDrain such that if omitted in code or in TalosUpgrade resources, the talos default is honored.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md): YES
- AI usage disclosure: NO