### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -44,6 +48,13 @@ jobs:
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       - name: Run linter
         run: mise run lint

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What

Mirrors [home-operations/kromgo#239](https://github.com/home-operations/kromgo/pull/239), tailored to this repo's workflows.

### Path filters
Added a `paths-ignore` block (skip doc-only changes) under the `push`/`pull_request` triggers of:
- `tests.yaml`
- `lint.yaml`
- `release.yaml` (under the `push:` trigger only — **not** the `release:` trigger)

```yaml
paths-ignore:
  - "**.md"
```

> `e2e.yaml` was intentionally left unchanged: its `pull_request:` trigger already uses an explicit `paths:` allow-list (`**.go`, `charts/**`, etc.), which GitHub treats as mutually exclusive with `paths-ignore`, and that allow-list already excludes Markdown by construction.

### Concurrency
- `release.yaml` — added a concurrency group keyed on `${{ github.workflow }}-${{ github.ref }}` that cancels superseded `main` builds but **never** interrupts a published release (`cancel-in-progress: ${{ github.event_name != 'release' }}`).
- `release-please.yaml` — added a concurrency group with `cancel-in-progress: false`.

(`tests.yaml`, `lint.yaml`, `e2e.yaml` already have a concurrency block, so they were left as-is.)

### golangci-lint cache
- `lint.yaml` — added a dedicated `actions/cache` step for `~/.cache/golangci-lint`, immediately after the existing Go module/build cache, keyed on `hashFiles('go.sum', '.golangci.yml')`.

## Safe to merge
The repo has no required status checks, so changing trigger paths / adding concurrency cannot block merges. `zizmor --offline` reports no new findings on the changed workflows.
