### PR TITLE
ci: name the e2e jobs and capitalize the E2E workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: e2e
+name: E2E
 
 on:
   pull_request:
@@ -26,6 +26,7 @@ permissions:
 
 jobs:
   prune:
+    name: Prune previous runs
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -51,6 +52,7 @@ jobs:
         run: ./prune.sh "branch=${BRANCH}"
 
   e2e-test:
+    name: E2E (${{ matrix.controllers }}cp/${{ matrix.workers }}w)
     if: github.event_name == 'workflow_dispatch' || github.event.action != 'closed'
     needs: prune
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Applies the job-naming standardization findings to tuppr's `e2e.yaml` (its other workflows already use the `Go Tests`/`Go Lint`/`Helm …` convention):

- Workflow name `e2e` → **`E2E`** (every other app uses `E2E`).
- `prune` job → **`Prune previous runs`** (was unnamed).
- `e2e-test` job → **`E2E (${{ matrix.controllers }}cp/${{ matrix.workers }}w)`** (was unnamed) — matrix-interpolated so the two legs show distinct check names (`E2E (3cp/0w)`, `E2E (1cp/1w)`), mirroring kopiur's `E2E (<shard>)` style.

Cosmetic `name:`-only changes — no behavior impact (job keys, triggers, steps untouched). zizmor clean.
