### PR TITLE
spike(talos): drive upgrade-pod placement via PreferNoSchedule taint instead of affinity

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -27,6 +27,8 @@ const (
 // Node taint constants
 const (
 	NodeOutdatedTaint = "tuppr.home-operations.com/outdated"
+	// NodeUpgradingTaint steers the upgrade pod off the node it's about to reboot.
+	NodeUpgradingTaint = "tuppr.home-operations.com/upgrading-now"
 )
 
 // Talos config secret constants

--- a/internal/controller/jobs/jobs.go
+++ b/internal/controller/jobs/jobs.go
@@ -30,10 +30,17 @@ type PodSpecOptions struct {
 	GracePeriod       int64
 	Affinity          *corev1.Affinity
 	HostAliases       []corev1.HostAlias
+	// Tolerations overrides the default catch-all toleration (nil tolerates every taint).
+	Tolerations []corev1.Toleration
 }
 
 // BuildTalosctlPodSpec returns the shared pod spec used by both upgrade controllers.
 func BuildTalosctlPodSpec(opts PodSpecOptions) corev1.PodSpec {
+	tolerations := opts.Tolerations
+	if tolerations == nil {
+		tolerations = []corev1.Toleration{{Operator: corev1.TolerationOpExists}}
+	}
+
 	spec := corev1.PodSpec{
 		RestartPolicy:                 corev1.RestartPolicyNever,
 		TerminationGracePeriodSeconds: ptr.To(opts.GracePeriod),
@@ -47,11 +54,7 @@ func BuildTalosctlPodSpec(opts PodSpecOptions) corev1.PodSpec {
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
-		Tolerations: []corev1.Toleration{
-			{
-				Operator: corev1.TolerationOpExists,
-			},
-		},
+		Tolerations: tolerations,
 		Containers: []corev1.Container{{
 			Name:            opts.ContainerName,
 			Image:           opts.Image,

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -1826,8 +1826,8 @@ func TestTalosBuildJob_Properties(t *testing.T) {
 		t.Fatal("expected ReadOnlyRootFilesystem=true")
 	}
 
-	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		t.Fatal("expected required node affinity for hard placement")
+	if podSpec.Affinity != nil {
+		t.Fatal("expected no node affinity with taint-driven placement")
 	}
 
 	wantArgs := map[string]bool{
@@ -1850,9 +1850,6 @@ func TestTalosBuildJob_Properties(t *testing.T) {
 		}
 	}
 
-	if len(podSpec.Tolerations) != 1 || podSpec.Tolerations[0].Operator != corev1.TolerationOpExists {
-		t.Fatal("expected universal toleration")
-	}
 	if podSpec.PriorityClassName != "system-node-critical" {
 		t.Fatalf("expected system-node-critical priority, got: %s", podSpec.PriorityClassName)
 	}
@@ -2114,10 +2111,9 @@ func TestNodeNeedsUpgrade(t *testing.T) {
 	}
 }
 
-func TestTalosBuildJob_SoftPlacement(t *testing.T) {
+func TestTalosBuildJob_TaintTolerations(t *testing.T) {
 	scheme := newTestScheme()
 	tu := newTalosUpgrade(testUpgradeName, withFinalizer)
-	tu.Spec.Policy.Placement = PlacementSoft
 	tc := &mockTalosClient{
 		nodeVersions:  map[string]string{testNodeIP1: testV110Talos},
 		installImages: map[string]string{testNodeIP1: testFactoryInstaller},
@@ -2128,11 +2124,19 @@ func TestTalosBuildJob_SoftPlacement(t *testing.T) {
 	targetImage := "factory.talos.dev/installer:" + fakeTalosVersion
 	job := r.buildJob(context.Background(), tu, fakeNodeA, testNodeIP1, testNodeIP1, targetImage)
 	podSpec := job.Spec.Template.Spec
-	if podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution == nil {
-		t.Fatal("expected preferred node affinity for soft placement")
+
+	if podSpec.Affinity != nil {
+		t.Fatal("expected no node affinity with taint-driven placement")
 	}
-	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-		t.Fatal("soft placement should not have required affinity")
+	effects := map[corev1.TaintEffect]bool{}
+	for _, tol := range podSpec.Tolerations {
+		effects[tol.Effect] = true
+	}
+	if !effects[corev1.TaintEffectNoSchedule] || !effects[corev1.TaintEffectNoExecute] {
+		t.Fatalf("expected NoSchedule and NoExecute tolerations, got: %+v", podSpec.Tolerations)
+	}
+	if effects[corev1.TaintEffectPreferNoSchedule] {
+		t.Fatal("upgrade pod must not tolerate PreferNoSchedule")
 	}
 }
 

--- a/internal/controller/talosupgrade/jobs.go
+++ b/internal/controller/talosupgrade/jobs.go
@@ -241,6 +241,10 @@ func (r *Reconciler) processSingleJobSuccess(ctx context.Context, talosUpgrade *
 		logger.Error(err, "Failed to remove upgrading label from node", "node", nodeName)
 	}
 
+	if err := r.removeNodeUpgradingTaint(ctx, nodeName); err != nil {
+		logger.Error(err, "Failed to remove upgrading taint from node", "node", nodeName)
+	}
+
 	if err := r.addCompletedNode(ctx, talosUpgrade, nodeName); err != nil {
 		logger.Error(err, "Failed to add completed node", "node", nodeName)
 		return jobResultSuccess, err
@@ -285,6 +289,10 @@ func (r *Reconciler) processSingleJobFailure(ctx context.Context, talosUpgrade *
 
 	if err := r.removeNodeUpgradingLabel(ctx, nodeName); err != nil {
 		logger.Error(err, "Failed to remove upgrading label from node", "node", nodeName)
+	}
+
+	if err := r.removeNodeUpgradingTaint(ctx, nodeName); err != nil {
+		logger.Error(err, "Failed to remove upgrading taint from node", "node", nodeName)
 	}
 
 	nodeStatus := tupprv1alpha1.NodeUpgradeStatus{
@@ -348,6 +356,11 @@ func (r *Reconciler) createJob(ctx context.Context, talosUpgrade *tupprv1alpha1.
 
 	endpointIP := r.pickEndpointIP(ctx, targetNode, nodeIP)
 
+	// Taint before the pod exists so the scheduler steers it off this node. Best-effort.
+	if err := r.addNodeUpgradingTaint(ctx, nodeName); err != nil {
+		logger.Error(err, "Failed to add upgrading taint to node", "node", nodeName)
+	}
+
 	job := r.buildJob(ctx, talosUpgrade, nodeName, nodeIP, endpointIP, targetImage)
 	if err := controllerutil.SetControllerReference(talosUpgrade, job, r.Scheme); err != nil {
 		logger.Error(err, "Failed to set controller reference", "job", job.Name)
@@ -407,41 +420,11 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 		targetNodeLabelKey:  nodeName,
 	}
 
-	placement := talosUpgrade.Spec.Policy.Placement
-	if placement == "" {
-		placement = PlacementSoft
-	}
-
-	nodeSelector := corev1.NodeSelectorRequirement{
-		Key:      "kubernetes.io/hostname",
-		Operator: corev1.NodeSelectorOpNotIn,
-		Values:   []string{nodeName},
-	}
-
-	var nodeAffinity *corev1.NodeAffinity
-	if placement == "hard" {
-		nodeAffinity = &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
-					MatchExpressions: []corev1.NodeSelectorRequirement{nodeSelector},
-				}},
-			},
-		}
-		logger.V(1).Info("Using hard placement preset - required node avoidance", "node", nodeName)
-	} else {
-		nodeAffinity = &corev1.NodeAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
-				Weight: 100,
-				Preference: corev1.NodeSelectorTerm{
-					MatchExpressions: []corev1.NodeSelectorRequirement{nodeSelector},
-				},
-			}},
-		}
-		if placement != PlacementSoft {
-			logger.V(1).Info("Unknown placement preset, using soft placement as fallback", "preset", placement, "node", nodeName)
-		} else {
-			logger.V(1).Info("Using soft placement preset - preferred node avoidance", "node", nodeName)
-		}
+	// Tolerate hard taints so the pod can land on any node, but not PreferNoSchedule,
+	// so the target's upgrading taint steers it off (without blocking a single node).
+	tolerations := []corev1.Toleration{
+		{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule},
+		{Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute},
 	}
 
 	talosctlRepo := constants.DefaultTalosctlImage
@@ -551,7 +534,7 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 					Args:              args,
 					TalosConfigSecret: r.TalosConfigSecret,
 					GracePeriod:       TalosJobGracePeriod,
-					Affinity:          &corev1.Affinity{NodeAffinity: nodeAffinity},
+					Tolerations:       tolerations,
 				}),
 			},
 		},

--- a/internal/controller/talosupgrade/nodes.go
+++ b/internal/controller/talosupgrade/nodes.go
@@ -124,7 +124,66 @@ func (r *Reconciler) removeNodeOutdatedTaint(ctx context.Context, nodeName strin
 	return nil
 }
 
-// clearOutdatedTaints removes the outdated taint from every selected node.
+// addNodeUpgradingTaint adds the PreferNoSchedule upgrading taint to a node.
+func (r *Reconciler) addNodeUpgradingTaint(ctx context.Context, nodeName string) error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node := &corev1.Node{}
+		if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+			return err
+		}
+
+		for i := range node.Spec.Taints {
+			if node.Spec.Taints[i].Key == constants.NodeUpgradingTaint {
+				return nil
+			}
+		}
+
+		node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+			Key:    constants.NodeUpgradingTaint,
+			Effect: corev1.TaintEffectPreferNoSchedule,
+		})
+		return r.Update(ctx, node)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add upgrading taint to node %s: %w", nodeName, err)
+	}
+	return nil
+}
+
+// removeNodeUpgradingTaint removes the upgrading taint from a node.
+func (r *Reconciler) removeNodeUpgradingTaint(ctx context.Context, nodeName string) error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		node := &corev1.Node{}
+		if err := r.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		filtered := make([]corev1.Taint, 0, len(node.Spec.Taints))
+		removed := false
+		for _, t := range node.Spec.Taints {
+			if t.Key == constants.NodeUpgradingTaint {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, t)
+		}
+		if !removed {
+			return nil
+		}
+
+		node.Spec.Taints = filtered
+		return r.Update(ctx, node)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to remove upgrading taint from node %s: %w", nodeName, err)
+	}
+	return nil
+}
+
+// clearOutdatedTaints removes the outdated and upgrading taints from every selected node.
 func (r *Reconciler) clearOutdatedTaints(ctx context.Context, talosUpgrade *tupprv1alpha1.TalosUpgrade) {
 	logger := log.FromContext(ctx)
 
@@ -136,6 +195,9 @@ func (r *Reconciler) clearOutdatedTaints(ctx context.Context, talosUpgrade *tupp
 	for i := range nodes {
 		if err := r.removeNodeOutdatedTaint(ctx, nodes[i].Name); err != nil {
 			logger.Error(err, "Failed to remove outdated taint during cleanup", "node", nodes[i].Name)
+		}
+		if err := r.removeNodeUpgradingTaint(ctx, nodes[i].Name); err != nil {
+			logger.Error(err, "Failed to remove upgrading taint during cleanup", "node", nodes[i].Name)
 		}
 	}
 }

--- a/internal/controller/talosupgrade/nodes_test.go
+++ b/internal/controller/talosupgrade/nodes_test.go
@@ -169,6 +169,56 @@ func TestAddNodeOutdatedTaint(t *testing.T) {
 	}
 }
 
+func TestAddAndRemoveNodeUpgradingTaint(t *testing.T) {
+	scheme := newTestScheme()
+	other := corev1.Taint{Key: labelFooKey, Effect: corev1.TaintEffectNoSchedule}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: fakeNodeA},
+		Spec:       corev1.NodeSpec{Taints: []corev1.Taint{other}},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(node).Build()
+	r := &Reconciler{Client: cl}
+
+	if err := r.addNodeUpgradingTaint(context.Background(), fakeNodeA); err != nil {
+		t.Fatalf("addNodeUpgradingTaint failed: %v", err)
+	}
+
+	var tainted corev1.Node
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: fakeNodeA}, &tainted); err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	found := false
+	for _, tt := range tainted.Spec.Taints {
+		if tt.Key == constants.NodeUpgradingTaint {
+			if tt.Effect != corev1.TaintEffectPreferNoSchedule {
+				t.Fatalf("expected PreferNoSchedule, got %s", tt.Effect)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected upgrading taint to be present")
+	}
+
+	if err := r.removeNodeUpgradingTaint(context.Background(), fakeNodeA); err != nil {
+		t.Fatalf("removeNodeUpgradingTaint failed: %v", err)
+	}
+
+	var cleared corev1.Node
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: fakeNodeA}, &cleared); err != nil {
+		t.Fatalf("failed to get node: %v", err)
+	}
+	for _, tt := range cleared.Spec.Taints {
+		if tt.Key == constants.NodeUpgradingTaint {
+			t.Fatal("expected upgrading taint to be removed")
+		}
+	}
+	if len(cleared.Spec.Taints) != 1 {
+		t.Fatalf("expected the unrelated taint to be preserved, got %d", len(cleared.Spec.Taints))
+	}
+}
+
 func TestAddNodeOutdatedTaint_Idempotent(t *testing.T) {
 	scheme := newTestScheme()
 	node := &corev1.Node{


### PR DESCRIPTION
Draft / RFC for the Flux thread discussion — not intended to merge as-is.

Alternative to node-affinity for keeping the Talos upgrade pod off the node it's about to reboot (where it would otherwise be killed by its own drain).

## Approach

Taint the target `tuppr.home-operations.com/upgrading-now:PreferNoSchedule` before the Job is created, and let the scheduler steer the pod off it.

- `createJob` taints the target before `r.Create`, so the pod sees the taint at schedule time (not next to `addNodeUpgradingLabel`, which runs after job creation).
- Toleration split: the pod drops the catch-all `{Operator: Exists}` (which tolerated `PreferNoSchedule` too, defeating any steering) and tolerates only `NoSchedule` + `NoExecute`. It can still land on any hard-tainted node but no longer tolerates `PreferNoSchedule`. Opt-in via a new `PodSpecOptions.Tolerations` field, so KubernetesUpgrade is unchanged.
- Affinity removed from `buildJob`.
- Taint cleaned up on success, failure, and the finalizer.

`PreferNoSchedule` never blocks, so a single-node cluster still gets the pod on its only node — no `selfHosted` special-casing.

## Open questions

1. `placement` field is now vestigial (still in CRD + webhook-validated, unread). Dropping it is a breaking CRD change — left in for discussion.
2. Both `outdated` (#318) and `upgrading-now` are now un-tolerated `PreferNoSchedule`. At upgrade start every node carries `outdated`; the target also carries `upgrading-now`, so it stays most-avoided. Works, but placement is emergent from taint scoring rather than an explicit rule.
3. The toleration split is the subtle part — worth scrutiny.

Affinity-based alternative (default `placement: hard`, degrade to preferred on single-node) is on `fix/placement-hard-default` for comparison.

Unit tests + lint green; integration/e2e not run (need envtest/Kind).