### PR TITLE
fix(talos): default placement to hard, degrade to preferred on single-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ spec:
         force: false # Optional, skip etcd health checks
         rebootMode: default # Optional, default|powercycle
         placement: hard # Optional, hard|soft (default hard)
+        priorityClassName: system-node-critical # Optional, job pod priority class
         stage: false # Optional, stage upgrade
         timeout: 30m # Optional, per-node upgrade timeout
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ spec:
         debug: true # Optional, verbose logging
         force: false # Optional, skip etcd health checks
         rebootMode: default # Optional, default|powercycle
-        placement: soft # Optional, hard|soft
+        placement: hard # Optional, hard|soft (default hard)
         stage: false # Optional, stage upgrade
         timeout: 30m # Optional, per-node upgrade timeout
 

--- a/api/v1alpha1/talosupgrade_types.go
+++ b/api/v1alpha1/talosupgrade_types.go
@@ -31,10 +31,10 @@ type PolicySpec struct {
 	NoDrain bool `json:"nodrain,omitempty"`
 
 	// Placement controls how strictly upgrade jobs avoid the target node
-	// hard: required avoidance (job will fail if can't avoid target node)
+	// hard: required avoidance, degrades to preferred on single-node clusters
 	// soft: preferred avoidance (job prefers to avoid but can run on target node)
 	// +kubebuilder:validation:Enum=hard;soft
-	// +kubebuilder:default="soft"
+	// +kubebuilder:default="hard"
 	// +optional
 	Placement string `json:"placement,omitempty"`
 

--- a/api/v1alpha1/talosupgrade_types.go
+++ b/api/v1alpha1/talosupgrade_types.go
@@ -49,6 +49,11 @@ type PolicySpec struct {
 	// +optional
 	Stage bool `json:"stage,omitempty"`
 
+	// PriorityClassName for the upgrade job pod; set a preempting class to displace lower-priority pods under resource pressure.
+	// +kubebuilder:default="system-node-critical"
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// Timeout for the per-node talosctl upgrade command
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Pattern=`^([0-9]+[smh])+$`

--- a/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
@@ -4796,10 +4796,10 @@ spec:
                     description: NoDrain disables drain for the upgrade.
                     type: boolean
                   placement:
-                    default: soft
+                    default: hard
                     description: |-
                       Placement controls how strictly upgrade jobs avoid the target node
-                      hard: required avoidance (job will fail if can't avoid target node)
+                      hard: required avoidance, degrades to preferred on single-node clusters
                       soft: preferred avoidance (job prefers to avoid but can run on target node)
                     enum:
                     - hard

--- a/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
@@ -4805,6 +4805,12 @@ spec:
                     - hard
                     - soft
                     type: string
+                  priorityClassName:
+                    default: system-node-critical
+                    description: PriorityClassName for the upgrade job pod; set a
+                      preempting class to displace lower-priority pods under resource
+                      pressure.
+                    type: string
                   rebootMode:
                     default: default
                     description: RebootMode select the reboot mode during upgrade

--- a/internal/controller/jobs/jobs.go
+++ b/internal/controller/jobs/jobs.go
@@ -30,14 +30,20 @@ type PodSpecOptions struct {
 	GracePeriod       int64
 	Affinity          *corev1.Affinity
 	HostAliases       []corev1.HostAlias
+	PriorityClassName string
 }
 
 // BuildTalosctlPodSpec returns the shared pod spec used by both upgrade controllers.
 func BuildTalosctlPodSpec(opts PodSpecOptions) corev1.PodSpec {
+	priorityClassName := opts.PriorityClassName
+	if priorityClassName == "" {
+		priorityClassName = "system-node-critical"
+	}
+
 	spec := corev1.PodSpec{
 		RestartPolicy:                 corev1.RestartPolicyNever,
 		TerminationGracePeriodSeconds: ptr.To(opts.GracePeriod),
-		PriorityClassName:             "system-node-critical",
+		PriorityClassName:             priorityClassName,
 		SecurityContext: &corev1.PodSecurityContext{
 			RunAsNonRoot: ptr.To(true),
 			RunAsUser:    ptr.To(int64(65532)),

--- a/internal/controller/talosupgrade/controller.go
+++ b/internal/controller/talosupgrade/controller.go
@@ -43,6 +43,7 @@ const (
 	TalosJobActiveDeadlineBuffer = 600
 	TalosJobDefaultTimeout       = 30 * time.Minute
 	PlacementSoft                = "soft"
+	PlacementHard                = "hard"
 )
 
 const (

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -2137,6 +2137,36 @@ func TestTalosBuildJob_SoftPlacement(t *testing.T) {
 	}
 }
 
+func TestTalosBuildJob_PriorityClassName(t *testing.T) {
+	scheme := newTestScheme()
+	tc := &mockTalosClient{
+		nodeVersions:  map[string]string{testNodeIP1: testV110Talos},
+		installImages: map[string]string{testNodeIP1: testFactoryInstaller},
+	}
+	targetImage := "factory.talos.dev/installer:" + fakeTalosVersion
+
+	// Custom class is passed through.
+	custom := newTalosUpgrade(testUpgradeName, withFinalizer)
+	custom.Spec.Policy.PriorityClassName = "my-preempting-class"
+	clCustom := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(custom, newNode(fakeNodeA, testNodeIP1)).WithStatusSubresource(custom).Build()
+	rCustom := newTalosReconciler(clCustom, scheme, tc, &mockHealthChecker{})
+	jobCustom := rCustom.buildJob(context.Background(), custom, fakeNodeA, testNodeIP1, testNodeIP1, targetImage)
+	if got := jobCustom.Spec.Template.Spec.PriorityClassName; got != "my-preempting-class" {
+		t.Fatalf("expected custom priority class, got: %s", got)
+	}
+
+	// Unset falls back to system-node-critical.
+	def := newTalosUpgrade(testUpgradeName, withFinalizer)
+	clDef := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(def, newNode(fakeNodeA, testNodeIP1)).WithStatusSubresource(def).Build()
+	rDef := newTalosReconciler(clDef, scheme, tc, &mockHealthChecker{})
+	jobDef := rDef.buildJob(context.Background(), def, fakeNodeA, testNodeIP1, testNodeIP1, targetImage)
+	if got := jobDef.Spec.Template.Spec.PriorityClassName; got != "system-node-critical" {
+		t.Fatalf("expected system-node-critical fallback, got: %s", got)
+	}
+}
+
 func TestTalosBuildJob_HardPlacementSingleNodeDegrades(t *testing.T) {
 	scheme := newTestScheme()
 	tu := newTalosUpgrade(testUpgradeName, withFinalizer)

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -1797,7 +1797,8 @@ func TestTalosBuildJob_Properties(t *testing.T) {
 		installImages: map[string]string{testNodeIP1: testFactoryInstaller},
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).
-		WithObjects(tu, newNode(fakeNodeA, testNodeIP1)).WithStatusSubresource(tu).Build()
+		WithObjects(tu, newNode(fakeNodeA, testNodeIP1), newNode(fakeNodeB, testNodeIP2)).
+		WithStatusSubresource(tu).Build()
 	r := newTalosReconciler(cl, scheme, tc, &mockHealthChecker{})
 	targetImage := "factory.talos.dev/installer:" + fakeTalosVersion
 
@@ -2133,6 +2134,29 @@ func TestTalosBuildJob_SoftPlacement(t *testing.T) {
 	}
 	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 		t.Fatal("soft placement should not have required affinity")
+	}
+}
+
+func TestTalosBuildJob_HardPlacementSingleNodeDegrades(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade(testUpgradeName, withFinalizer)
+	tu.Spec.Policy.Placement = PlacementHard
+	tc := &mockTalosClient{
+		nodeVersions:  map[string]string{testNodeIP1: testV110Talos},
+		installImages: map[string]string{testNodeIP1: testFactoryInstaller},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, newNode(fakeNodeA, testNodeIP1)).WithStatusSubresource(tu).Build()
+	r := newTalosReconciler(cl, scheme, tc, &mockHealthChecker{})
+	targetImage := "factory.talos.dev/installer:" + fakeTalosVersion
+	job := r.buildJob(context.Background(), tu, fakeNodeA, testNodeIP1, testNodeIP1, targetImage)
+	podSpec := job.Spec.Template.Spec
+	// Required avoidance is unsatisfiable on a single node, so it must degrade to preferred.
+	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		t.Fatal("hard placement on a single-node cluster must not produce required affinity")
+	}
+	if podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("expected preferred node affinity when hard placement degrades on a single node")
 	}
 }
 

--- a/internal/controller/talosupgrade/jobs.go
+++ b/internal/controller/talosupgrade/jobs.go
@@ -409,8 +409,12 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 
 	placement := talosUpgrade.Spec.Policy.Placement
 	if placement == "" {
-		placement = PlacementSoft
+		placement = PlacementHard
 	}
+
+	// A single node can only run the pod on the node it upgrades, so a required
+	// avoidance would be unsatisfiable; degrade hard to preferred there.
+	selfHosted := r.isSelfHostedUpgrade(ctx)
 
 	nodeSelector := corev1.NodeSelectorRequirement{
 		Key:      "kubernetes.io/hostname",
@@ -419,7 +423,7 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 	}
 
 	var nodeAffinity *corev1.NodeAffinity
-	if placement == "hard" {
+	if placement == PlacementHard && !selfHosted {
 		nodeAffinity = &corev1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
 				NodeSelectorTerms: []corev1.NodeSelectorTerm{{
@@ -437,10 +441,13 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 				},
 			}},
 		}
-		if placement != PlacementSoft {
-			logger.V(1).Info("Unknown placement preset, using soft placement as fallback", "preset", placement, "node", nodeName)
-		} else {
+		switch {
+		case placement == PlacementHard && selfHosted:
+			logger.V(1).Info("Single-node cluster - downgrading hard placement to preferred node avoidance", "node", nodeName)
+		case placement == PlacementSoft:
 			logger.V(1).Info("Using soft placement preset - preferred node avoidance", "node", nodeName)
+		default:
+			logger.V(1).Info("Unknown placement preset, using soft placement as fallback", "preset", placement, "node", nodeName)
 		}
 	}
 
@@ -468,8 +475,6 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 	if talosUpgrade.Spec.Policy.Timeout != nil {
 		timeout = talosUpgrade.Spec.Policy.Timeout.Duration
 	}
-
-	selfHosted := r.isSelfHostedUpgrade(ctx)
 
 	// On a single-node cluster the pod runs on the node it upgrades, so --wait would
 	// have it killed by the reboot and fail the Job. Issue the upgrade and exit; the

--- a/internal/controller/talosupgrade/jobs.go
+++ b/internal/controller/talosupgrade/jobs.go
@@ -557,6 +557,7 @@ func (r *Reconciler) buildJob(ctx context.Context, talosUpgrade *tupprv1alpha1.T
 					TalosConfigSecret: r.TalosConfigSecret,
 					GracePeriod:       TalosJobGracePeriod,
 					Affinity:          &corev1.Affinity{NodeAffinity: nodeAffinity},
+					PriorityClassName: talosUpgrade.Spec.Policy.PriorityClassName,
 				}),
 			},
 		},


### PR DESCRIPTION
Keeps the Talos upgrade pod off the node it's about to reboot, so it isn't killed by its own drain.

## Problem

With the default `placement: soft`, the anti-affinity keeping the upgrade pod off the target node is only a `PreferredDuringScheduling` hint, so the scheduler can place the pod on the node being upgraded. talosctl then drains that node and evicts its own pod, breaking the upgrade.

## Change

- Default `placement` flips `soft` → `hard` (`RequiredDuringScheduling: kubernetes.io/hostname NotIn [target]`), so the pod can't land on the node it's upgrading.
- On a single-node cluster `hard` is unsatisfiable, so it degrades to preferred — the pod runs on the only node, and the existing `--wait=false` / `--drain=false` (gated on the same single-node detection) keep it from being killed by its own drain.
- `soft` remains as an explicit opt-out.

## Why `hard` as the default

`soft` can place the pod on the rebooting node and silently drain-kill it. `hard` instead leaves a visible Pending pod, and only if no non-target node can fit a 10m/64Mi `system-node-critical` pod even after preemption. Single-node is safe either way (degrade), and the existing `system-node-critical` priority lets the pod preempt onto a non-target node under resource pressure.

## Notes

- The #318 `outdated` PreferNoSchedule taint is unaffected; it handles cluster-wide workload churn, separate from the upgrade pod's own placement.
- Closes the taint-based spike #334, which can't express a hard constraint without breaking the pod's blanket toleration and can't force preemption off the target.

## Testing

Unit tests + lint green. Reworked placement tests, added a single-node hard-degrade test, regenerated the CRD. Integration/e2e not run (need envtest/Kind).