### PR TITLE
ci: emit OCI image labels and annotations via the builder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,8 @@ jobs:
       platforms: linux/amd64,linux/arm64
       push: true
       sbom: true
+      set-meta-annotations: true
+      set-meta-labels: true
       sign: true
     secrets:
       registry-auths: |


### PR DESCRIPTION
The published image carries **no** OCI labels today (`skopeo inspect … | .Labels` → `{}`), so Renovate can't resolve `org.opencontainers.image.source` and can't surface this image's changelog/release notes on dependency PRs.

`docker/github-builder` already runs `docker/metadata-action` (we pass `meta-images`/`meta-tags`) — it just wasn't applying the generated metadata. This flips on the two builder toggles:

- `set-meta-labels: true` — appends metadata-action's OCI **labels**, including `org.opencontainers.image.source` (the repo URL Renovate reads), plus `revision`, `created`, `title`, `version`, …
- `set-meta-annotations: true` — appends the matching OCI manifest **annotations** (best practice for multi-arch images).

All derived from git context at build time — no Dockerfile `LABEL` to maintain or drift. Fleet-wide change; sibling repos get the same toggle.

Takes effect on the next release build. No app/runtime change.
