### PR TITLE
build: standardize on the distroless/static:nonroot base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 # Build the manager binary
 ARG GO_VERSION
-FROM golang:${GO_VERSION} AS builder
+FROM golang:${GO_VERSION}-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev
 ARG REVISION=dev
+
+# upx (build stage only) compresses the final binary to shrink the image.
+RUN apk add --no-cache upx
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -28,11 +31,12 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
     go build -a -ldflags "-X main.version=${VERSION} -X main.commit=${REVISION}" \
     -o manager cmd/main.go
 
+RUN upx --best --lzma manager
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/charts/tuppr/README.md
+++ b/charts/tuppr/README.md
@@ -86,7 +86,7 @@ Kubernetes: `>=1.25.0-0`
 | notification.secretName | string | `""` | Name of the Secret holding the notification (shoutrrr) URL. |
 | podAnnotations | object | `{}` | Annotations added to the pod. |
 | podLabels | object | `{}` | Labels added to the pod. |
-| podSecurityContext | object | `{"fsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Pod-level securityContext (runs as non-root uid/gid 65532). |
+| podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | Pod-level securityContext (runs as non-root uid/gid 65532). |
 | priorityClassName | string | `"system-node-critical"` | Priority class name for pod scheduling. |
 | rbac.annotations | object | `{}` | Annotations for the RBAC resources. |
 | rbac.create | bool | `true` | Create the ClusterRole + ClusterRoleBinding the controller needs to manage nodes and jobs. |

--- a/charts/tuppr/values.schema.json
+++ b/charts/tuppr/values.schema.json
@@ -416,6 +416,11 @@
           "title": "fsGroup",
           "type": "integer"
         },
+        "runAsGroup": {
+          "default": 65532,
+          "title": "runAsGroup",
+          "type": "integer"
+        },
         "runAsNonRoot": {
           "default": true,
           "title": "runAsNonRoot",

--- a/charts/tuppr/values.yaml
+++ b/charts/tuppr/values.yaml
@@ -45,6 +45,7 @@ podLabels: {}
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
+  runAsGroup: 65532
   fsGroup: 65532
 
 # -- Extra environment variables passed to the container.


### PR DESCRIPTION
Standardizes the image on the fleet base — **`gcr.io/distroless/static:nonroot`** runtime, built from a `golang-alpine` (+ `node-alpine` where the UI build needs it) builder with `upx` compression.

- **Runtime → `gcr.io/distroless/static:nonroot`** — it bundles CA certs, `/etc/passwd`, and a nonroot user (uid/gid **65532**), so the hand-rolled `COPY ca-certificates.crt` / `/etc/passwd` and the `USER` directive are dropped; the base provides them.
- **Builder → `golang:${GO_VERSION}-alpine`** (and `node:${NODE_VERSION}-alpine` where used), with `upx --best --lzma` on the binary — now consistent across the fleet.
- **Chart `podSecurityContext`** pins `runAsUser`/`runAsGroup`/`fsGroup: 65532` to match the base (where this repo ships a chart).

No behavior change — the static binary runs identically. Verified locally: the alpine-built, upx-compressed binary builds and serves on `distroless/static:nonroot`.
