### PR TITLE
fix(chart): honor serviceAccount.automount=false

### DIFF
--- a/charts/tuppr/templates/serviceaccount.tpl
+++ b/charts/tuppr/templates/serviceaccount.tpl
@@ -10,7 +10,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount | default true }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}
 ---
 apiVersion: talos.dev/v1alpha1

--- a/charts/tuppr/tests/serviceaccount_test.yaml
+++ b/charts/tuppr/tests/serviceaccount_test.yaml
@@ -49,3 +49,19 @@ tests:
       - equal:
           path: metadata.annotations.foo
           value: bar
+
+  - it: should mount the API token by default
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: should honor automount=false instead of forcing true
+    set:
+      serviceAccount.automount: false
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false


### PR DESCRIPTION
## Problem
`automountServiceAccountToken: {{ .Values.serviceAccount.automount | default true }}` treats `false` as empty, so `| default true` forces the token to mount even when a user sets `serviceAccount.automount: false` — the toggle cannot be turned off.

## Fix
Render the value directly (`{{ .Values.serviceAccount.automount }}`), matching the `echo` chart, so both `true` and `false` are honored. The chart default stays `true` (tuppr's controller talks to the cluster API).

## Tests
Adds two helm-unittest cases: the default mounts the token (`true`), and `automount: false` now renders `false` (regression guard). All 7 suites pass (`mise run helm-test`).