### PR TITLE
feat: serve metrics and health on a single 8081 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,8 +447,8 @@ kubectl annotate node <node-name> tuppr.home-operations.com/version="v1.10.7"
 kubectl get nodes -o custom-columns=NAME:.metadata.name,VERSION-OVERRIDE:.metadata.annotations."tuppr\.home-operations\.com/version"
 
 # Check metrics endpoint
-kubectl port-forward -n system-upgrade deployment/tuppr 8080:8080
-curl http://localhost:8080/metrics | grep tuppr_
+kubectl port-forward -n system-upgrade deployment/tuppr 8081:8081
+curl http://localhost:8081/metrics | grep tuppr_
 ```
 
 ### Suspending Upgrades
@@ -497,8 +497,8 @@ kubectl logs job/tuppr-xyz -n system-upgrade
 kubectl get pods -n system-upgrade -l app.kubernetes.io/name=tuppr
 
 # View metrics for debugging
-kubectl port-forward -n system-upgrade deployment/tuppr 8080:8080
-curl http://localhost:8080/metrics | grep -E "(tuppr_.*_phase|tuppr_.*_duration)"
+kubectl port-forward -n system-upgrade deployment/tuppr 8081:8081
+curl http://localhost:8081/metrics | grep -E "(tuppr_.*_phase|tuppr_.*_duration)"
 ```
 
 ### Emergency Procedures

--- a/charts/tuppr/README.md
+++ b/charts/tuppr/README.md
@@ -40,13 +40,13 @@ Kubernetes: `>=1.25.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod scheduling. |
-| controller.health.port | int | `8081` | Health-probe port (/healthz, /readyz). |
+| controller.health.port | int | `8081` | Health-probe port (/healthz, /readyz). When metrics use plain HTTP they are co-hosted on the metrics port; set this to a different port to serve them separately. |
 | controller.leaderElection.enabled | bool | `true` | Enable leader election (recommended; only one controller is active at a time). |
 | controller.logLevel | string | `"debug"` | Controller log level: info or debug. |
 | controller.metrics.annotations | object | `{}` | Annotations for the metrics Service. |
 | controller.metrics.enabled | bool | `true` | Expose the Prometheus metrics endpoint. |
-| controller.metrics.port | int | `8080` | Metrics endpoint port. |
-| controller.metrics.secure | bool | `false` | Serve metrics over HTTPS with authentication; false serves plain HTTP. |
+| controller.metrics.port | int | `8081` | Metrics endpoint port. When metrics are served over plain HTTP (secure: false), the /healthz and /readyz probes are co-hosted on this same port. |
+| controller.metrics.secure | bool | `false` | Serve metrics over HTTPS with authentication; false serves plain HTTP. Keep false so the health/readiness probes can share the metrics port. |
 | env | list | `[]` | Extra environment variables passed to the container. |
 | fullnameOverride | string | `""` | Override the full release name. |
 | image.digest | string | `""` | Pin the image by digest (sha256:…); when set, overrides the tag. |
@@ -94,7 +94,7 @@ Kubernetes: `>=1.25.0-0`
 | replicaCount | int | `1` | Number of controller replicas (only one is active at a time via leader election). |
 | resources | object | `{}` | Pod resource requests/limits. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65532}` | Container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
-| service.metricsPort | int | `8080` | Metrics port (deprecated — use controller.metrics.port). |
+| service.metricsPort | int | `8081` | Metrics port (deprecated — use controller.metrics.port). |
 | service.port | int | `8080` | Service port for general access. |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | Annotations for the ServiceAccount (e.g. workload-identity bindings). |

--- a/charts/tuppr/templates/deployment.tpl
+++ b/charts/tuppr/templates/deployment.tpl
@@ -89,9 +89,18 @@ spec:
               containerPort: {{ .Values.controller.metrics.port }}
               protocol: TCP
             {{- end }}
+            {{/* The controller co-hosts the /healthz and /readyz probes on the metrics
+                 listener whenever metrics are enabled and served over plain HTTP, exposing a
+                 single port. In that case the metrics port above already covers the probes, so
+                 don't declare a duplicate containerPort. A dedicated health port is only needed
+                 when the probes run on their own listener: metrics disabled, or metrics secure
+                 (HTTPS + authn/authz can't host plain-HTTP probes). Keep this in sync with the
+                 co-host decision in cmd/main.go. */}}
+            {{- if or (not .Values.controller.metrics.enabled) .Values.controller.metrics.secure }}
             - name: health
               containerPort: {{ .Values.controller.health.port }}
               protocol: TCP
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/tuppr/tests/deployment_test.yaml
+++ b/charts/tuppr/tests/deployment_test.yaml
@@ -84,10 +84,21 @@ tests:
           path: spec.template.spec.containers[0].ports
           content:
             name: metrics
-            containerPort: 8080
+            containerPort: 8081
             protocol: TCP
 
-  - it: should include health port
+  - it: should co-host probes on the metrics port by default (no separate health port)
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: health
+            containerPort: 8081
+            protocol: TCP
+
+  - it: should expose a dedicated health port when metrics are served securely
+    set:
+      controller.metrics.secure: true
     asserts:
       - contains:
           path: spec.template.spec.containers[0].ports
@@ -96,14 +107,49 @@ tests:
             containerPort: 8081
             protocol: TCP
 
-  - it: should set liveness and readiness probes
+  - it: should expose a dedicated health port when metrics are disabled
+    set:
+      controller.metrics.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: health
+            containerPort: 8081
+            protocol: TCP
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 8081
+            protocol: TCP
+
+  - it: should pass plain-HTTP metrics and probe bind flags
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-bind-address=:8081
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --health-probe-bind-address=:8081
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=false
+
+  - it: should set liveness and readiness probes on the shared port
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /healthz
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8081
+      - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8081
 
   - it: should set tolerations
     asserts:

--- a/charts/tuppr/tests/service_test.yaml
+++ b/charts/tuppr/tests/service_test.yaml
@@ -10,6 +10,15 @@ tests:
           path: spec.type
           value: ClusterIP
 
+  - it: should default the metrics port to 8081
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8081
+      - equal:
+          path: spec.ports[0].targetPort
+          value: metrics
+
   - it: should use correct metrics port
     set:
       controller.metrics.port: 9090

--- a/charts/tuppr/values.schema.json
+++ b/charts/tuppr/values.schema.json
@@ -14,7 +14,7 @@
           "properties": {
             "port": {
               "default": 8081,
-              "description": "Health-probe port (/healthz, /readyz).",
+              "description": "Health-probe port (/healthz, /readyz). When metrics use plain HTTP they are\nco-hosted on the metrics port; set this to a different port to serve them separately.",
               "title": "port",
               "type": "integer"
             }
@@ -57,14 +57,14 @@
               "type": "boolean"
             },
             "port": {
-              "default": 8080,
-              "description": "Metrics endpoint port.",
+              "default": 8081,
+              "description": "Metrics endpoint port. When metrics are served over plain HTTP (secure: false),\nthe /healthz and /readyz probes are co-hosted on this same port.",
               "title": "port",
               "type": "integer"
             },
             "secure": {
               "default": false,
-              "description": "Serve metrics over HTTPS with authentication; false serves plain HTTP.",
+              "description": "Serve metrics over HTTPS with authentication; false serves plain HTTP.\nKeep false so the health/readiness probes can share the metrics port.",
               "title": "secure",
               "type": "boolean"
             }
@@ -558,7 +558,7 @@
     "service": {
       "properties": {
         "metricsPort": {
-          "default": 8080,
+          "default": 8081,
           "description": "Metrics port (deprecated — use controller.metrics.port).",
           "title": "metricsPort",
           "type": "integer"

--- a/charts/tuppr/values.yaml
+++ b/charts/tuppr/values.yaml
@@ -77,7 +77,7 @@ service:
   # -- Service port for general access.
   port: 8080
   # -- Metrics port (deprecated — use controller.metrics.port).
-  metricsPort: 8080
+  metricsPort: 8081
 
 # -- Pod resource requests/limits.
 resources: {}
@@ -148,15 +148,18 @@ controller:
   metrics:
     # -- Expose the Prometheus metrics endpoint.
     enabled: true
-    # -- Metrics endpoint port.
-    port: 8080
+    # -- Metrics endpoint port. When metrics are served over plain HTTP (secure: false),
+    # the /healthz and /readyz probes are co-hosted on this same port.
+    port: 8081
     # -- Serve metrics over HTTPS with authentication; false serves plain HTTP.
+    # Keep false so the health/readiness probes can share the metrics port.
     secure: false
     # -- Annotations for the metrics Service.
     annotations: {}
 
   health:
-    # -- Health-probe port (/healthz, /readyz).
+    # -- Health-probe port (/healthz, /readyz). When metrics use plain HTTP they are
+    # co-hosted on the metrics port; set this to a different port to serve them separately.
     port: 8081
 
 webhook:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,9 +73,12 @@ func main() {
 	var logLevel string
 	var tlsOpts []func(*tls.Config)
 
-	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
-		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8081", "The address the metrics endpoint binds to. "+
+		"Use :8443 for HTTPS or :8081 for HTTP, or leave as 0 to disable the metrics service. "+
+		"When metrics are served over plain HTTP (--metrics-secure=false), the health/readiness "+
+		"probes are co-hosted on this same listener and --health-probe-bind-address is ignored.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to. "+
+		"Ignored when metrics are served over plain HTTP, since the probes are then co-hosted on the metrics listener.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -186,11 +189,28 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
+	// When metrics are served over plain HTTP, co-host the health/readiness probes on
+	// the metrics listener so the controller exposes a single port (e.g. :8081). The
+	// probes are registered as ExtraHandlers on the metrics server below, after the
+	// manager is built. We must NOT do this when metrics are served securely: the
+	// metrics server wraps every ExtraHandler in the same TLS listener and authn/authz
+	// FilterProvider as /metrics, which would make the kubelet's plain-HTTP, unauthenticated
+	// probes fail. In that case (and when metrics are disabled) we keep controller-runtime's
+	// dedicated health-probe server on its own port.
+	metricsEnabled := metricsAddr != "0"
+	coHostHealthOnMetrics := metricsEnabled && !secureMetrics
+
+	healthProbeBindAddress := probeAddr
+	if coHostHealthOnMetrics {
+		// Disable the separate health-probe server; probes are served on the metrics listener.
+		healthProbeBindAddress = "0"
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: probeAddr,
+		HealthProbeBindAddress: healthProbeBindAddress,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "bea89bcd.home-operations.com",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
@@ -329,16 +349,38 @@ func main() {
 		setupLog.Info("webhooks registered successfully")
 	}()
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+	// Health and readiness checks. healthz is a liveness ping; readyz reports ready once
+	// the webhook server has started so the cert rotator has wired up the webhooks.
+	var readyzCheck healthz.Checker = func(req *http.Request) error {
+		return mgr.GetWebhookServer().StartedChecker()(req)
 	}
 
-	if err := mgr.AddReadyzCheck("readyz", func(req *http.Request) error {
-		return mgr.GetWebhookServer().StartedChecker()(req)
-	}); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+	if coHostHealthOnMetrics {
+		// Serve the probes on the (plain HTTP) metrics listener so the controller exposes
+		// a single port. mgr.AddHealthzCheck/AddReadyzCheck only feed controller-runtime's
+		// dedicated health-probe server, which we disabled above, so register the checks as
+		// ExtraHandlers on the metrics server instead. healthz.CheckHandler returns 200 when
+		// the checker passes and 500 otherwise — the contract a kubelet HTTP probe expects.
+		if err := mgr.AddMetricsServerExtraHandler("/healthz", healthz.CheckHandler{Checker: healthz.Ping}); err != nil {
+			setupLog.Error(err, "unable to set up health check")
+			os.Exit(1)
+		}
+		if err := mgr.AddMetricsServerExtraHandler("/readyz", healthz.CheckHandler{Checker: readyzCheck}); err != nil {
+			setupLog.Error(err, "unable to set up ready check")
+			os.Exit(1)
+		}
+		setupLog.Info("serving health and readiness probes on the metrics listener", "bind-address", metricsAddr)
+	} else {
+		// Metrics are disabled or served securely; keep the probes on controller-runtime's
+		// dedicated health-probe server so they stay plain HTTP and unauthenticated.
+		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+			setupLog.Error(err, "unable to set up health check")
+			os.Exit(1)
+		}
+		if err := mgr.AddReadyzCheck("readyz", readyzCheck); err != nil {
+			setupLog.Error(err, "unable to set up ready check")
+			os.Exit(1)
+		}
 	}
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
## What

Serve the Prometheus metrics endpoint and the `/healthz` + `/readyz` probes on a **single port (8081)**, instead of metrics on 8080 and the probes on 8081.

## Why / approach

controller-runtime runs its metrics server and its health-probe server as **two separate `net.Listener`s** — they cannot bind the same address (you'd get `address already in use`). To expose one port, this PR serves the health/readiness checks as **`ExtraHandlers` on the controller-runtime metrics server** (`mgr.AddMetricsServerExtraHandler("/healthz", …)` / `"/readyz"`) and **disables the dedicated health-probe server** (`HealthProbeBindAddress = "0"`).

Because `mgr.AddHealthzCheck`/`AddReadyzCheck` only feed the (now-disabled) health-probe server, the checks are registered as `healthz.CheckHandler{…}` handlers on the metrics mux instead. `healthz.CheckHandler` returns 200 when its checker passes and 500 otherwise — the contract a kubelet HTTP probe expects. The readyz check still gates on the webhook server having started (unchanged).

### Important guard: only when metrics are plain HTTP

The metrics server applies the **same TLS listener and the same authn/authz `FilterProvider`** to every `ExtraHandler` that it applies to `/metrics` (see controller-runtime `pkg/metrics/server`). If metrics are served securely, co-hosting the probes there would force the kubelet to do TLS + present a bearer token + pass a `SubjectAccessReview` just to liveness-check the pod — which would break the probes.

So the consolidation is gated: probes are co-hosted on the metrics listener **only when metrics are enabled and `--metrics-secure=false`** (the chart default). When metrics are served securely or disabled, the probes keep running on controller-runtime's separate health-probe server — that path is unchanged. The chart wires `controller.metrics.secure: false` by default, so the single-port behavior is what ships.

## ⚠️ This changes the released ports

The chart previously exposed metrics on **8080** and probes on **8081**. It now exposes a **single 8081** port for both. Anything that scrapes/targets the old `:8080` metrics port (out-of-band scrapers, NetworkPolicies, dashboards using a hardcoded port) must move to `:8081`. The bundled `ServiceMonitor` targets the named `metrics` port and is unaffected.

## Changes

- **`cmd/main.go`**: `--metrics-bind-address` now defaults to `:8081`; co-host the probes on the metrics listener as `ExtraHandlers` when metrics are plain HTTP, disabling the separate health server in that case; keep the framework health/readiness checks on the separate server otherwise. Flag help updated.
- **`charts/tuppr/values.yaml`**: `controller.metrics.port` → `8081` (and the deprecated `service.metricsPort`). `controller.health.port` and the probe ports were already `8081`.
- **`charts/tuppr/templates/deployment.tpl`**: omit the dedicated `health` container port when the probes are co-hosted on the metrics listener (avoids declaring a duplicate `containerPort: 8081`); still emit it when metrics are secure or disabled. Kept in sync with the co-host decision in `cmd/main.go`.
- **`charts/tuppr/tests/*`**: assert the co-hosted default (single port, no separate `health` port), the secure/disabled fallback (separate `health` port present), the bind-address flags, and the probe ports.
- **Docs**: regenerated `charts/tuppr/README.md` + `values.schema.json`; updated the root `README.md` port-forward examples to `:8081`.

## Verification

- `go build` / `go vet` / `go test ./...` — pass
- `golangci-lint run` — 0 issues
- `helm lint` — pass
- `helm unittest` — 58/58 pass
- Rendered the chart across default (plain HTTP), `secure=true`, `metrics.enabled=false`, and a custom `health.port` to confirm no duplicate `containerPort` and correct probe ports in each case.
