### PR TITLE
chore(renovate): group Talos updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,5 +1,16 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
+  packageRules: [
+    {
+      groupName: "Talos Group",
+      matchPackageNames: [
+        "ghcr.io/siderolabs/installer",
+        "github.com/siderolabs/talos/pkg/machinery",
+        "talosctl",
+      ],
+      minimumGroupSize: 3,
+    },
+  ],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
 }


### PR DESCRIPTION
## Summary

- group the Talos installer, machinery module, and talosctl updates
- require all three updates to be available before Renovate creates the grouped branch

This consolidates the updates currently split across #395, #396, and #397.

## Validation

- `renovate-config-validator .renovaterc.json5`
- pre-commit `format-json` hook