### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/charts/tuppr/Chart.yaml
+++ b/charts/tuppr/Chart.yaml
@@ -6,8 +6,12 @@ type: application
 # Floor matching the chart's surface: restricted Pod Security (seccompProfile),
 # the admission webhook (admissionregistration.k8s.io/v1), and CRDs.
 kubeVersion: ">=1.25.0-0"
-version: 0.0.0
-appVersion: "0.0.0"
+# Chart + default image version, stamped by release-please on every release so
+# a git-sourced install deploys real image tags (the release workflow re-stamps
+# both at package time anyway; these keep the repo copy from going stale).
+version: 0.4.0 # x-release-please-version
+# Operator/image version this chart deploys by default.
+appVersion: "0.4.0" # x-release-please-version
 home: https://github.com/home-operations/tuppr
 sources:
   - https://github.com/home-operations/tuppr

--- a/charts/tuppr/Chart.yaml
+++ b/charts/tuppr/Chart.yaml
@@ -3,14 +3,8 @@ apiVersion: v2
 name: tuppr
 description: A Helm chart for tuppr - Talos Linux Upgrade Controller
 type: application
-# Floor matching the chart's surface: restricted Pod Security (seccompProfile),
-# the admission webhook (admissionregistration.k8s.io/v1), and CRDs.
 kubeVersion: ">=1.25.0-0"
-# Chart + default image version, stamped by release-please on every release so
-# a git-sourced install deploys real image tags (the release workflow re-stamps
-# both at package time anyway; these keep the repo copy from going stale).
 version: 0.4.0 # x-release-please-version
-# Operator/image version this chart deploys by default.
 appVersion: "0.4.0" # x-release-please-version
 home: https://github.com/home-operations/tuppr
 sources:

--- a/charts/tuppr/README.md
+++ b/charts/tuppr/README.md
@@ -1,6 +1,8 @@
 # tuppr
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.4.0&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.4.0&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 A Helm chart for tuppr - Talos Linux Upgrade Controller
 

--- a/charts/tuppr/README.md.gotmpl
+++ b/charts/tuppr/README.md.gotmpl
@@ -1,6 +1,14 @@
 {{ template "chart.header" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 {{ template "chart.description" . }}
 

--- a/charts/tuppr/tests/deployment_test.yaml
+++ b/charts/tuppr/tests/deployment_test.yaml
@@ -7,11 +7,13 @@ tests:
       - isKind:
           of: Deployment
 
-  - it: should use the correct image
+  # The tag floats with the release-please-stamped appVersion; assert the
+  # repo:semver shape rather than a hardcoded version.
+  - it: should default the image tag to the chart appVersion
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/home-operations/tuppr:0.0.0
+          pattern: ^ghcr\.io/home-operations/tuppr:\d+\.\d+\.\d+$
 
   - it: should use custom image tag
     set:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,8 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": ["charts/tuppr/Chart.yaml", "charts/tuppr/README.md"]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Follows the pattern from home-operations/kopiur@041549a: release-please stamps `version` and `appVersion` in `Chart.yaml` on every release (`x-release-please-version` annotations + `extra-files`), so a git-sourced chart install deploys a real image tag instead of the nonexistent `0.0.0`. The release workflow still re-stamps both at `helm package` time; this just keeps the repo copy from going stale.

Applying the pattern verbatim would have broken tuppr's CI, so two extra pieces were needed:

1. **The chart README is stamped too.** tuppr gates chart-docs staleness in CI (`helm-docs-check` in the tests workflow, which also runs on pushes to `main`). Since the README version badges are generated from `Chart.yaml`, a release PR that bumped only `Chart.yaml` would fail that check on the PR and then on `main` after merge. The README is therefore listed in `extra-files` with annotated badge lines. Two constraints from release-please's generic updater (verified against its source, `src/updaters/generic.ts`):
   - It replaces only the **first** semver occurrence per annotated line, so the version must appear exactly once per line - it is kept out of the badge alt text.
   - Its semver regex would swallow a shields.io path-style `-informational` color suffix as a prerelease (`Version-0.4.0-informational` → `Version-0.4.1`, corrupting the URL), so the version badges use the `static/v1?label=...&message=0.4.0&color=...` query form, where the version is delimited by `&`.

   Verified end to end by simulating the updater's exact regex/replacement on `Chart.yaml` + `README.md` and confirming `helm-docs` regeneration is byte-identical afterwards - so release PRs keep `helm-docs-check` green.
2. **The helm unittest image assertion** matched a hardcoded `tuppr:0.0.0`; it now asserts the `repo:semver` shape so it keeps passing as the stamped appVersion moves.

Chart renders with `image: ghcr.io/home-operations/tuppr:0.4.0`, `helm-docs-check` passes, helm lint passes, and all 54 chart unit tests pass.
