### PR TITLE
fix(release): use the generic updater for Chart.yaml stamping

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,10 @@
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
       "always-update": true,
-      "extra-files": ["charts/tuppr/Chart.yaml", "charts/tuppr/README.md"]
+      "extra-files": [
+        { "type": "generic", "path": "charts/tuppr/Chart.yaml" },
+        "charts/tuppr/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Fixes the Chart.yaml mangling visible in #412.

## Root cause

release-please picks the updater for a plain-string `extra-files` entry by file extension (`src/strategies/base.ts`, `extraFileUpdates`). A `.yaml` path gets `CompositeUpdater(GenericYaml('$.version'), Generic)`:

- `GenericYaml` parses and re-serializes the whole document to set `$.version` - stripping every comment (including the `x-release-please-version` annotations and the `---` marker) and normalizing quoting.
- The follow-up `Generic` pass then finds no annotations in the re-serialized content, so `appVersion` is never stamped.

That is exactly the #412 diff: comments wiped, `version: 0.4.1`, `appVersion` stuck at `0.4.0`. The README was unaffected because `.md` falls through to the pure `Generic` updater.

## Fix

Use the typed form to force annotation-based replacement for Chart.yaml:

```json
"extra-files": [
  { "type": "generic", "path": "charts/tuppr/Chart.yaml" },
  "charts/tuppr/README.md"
]
```

With `type: generic`, only annotated lines are touched: comments survive, and both `version` and `appVersion` get stamped, keeping the README/helm-docs round-trip intact.

## Follow-up

Once this merges, release-please will rebuild the #412 branch on its next run and the release PR should come out clean - #412 should not be merged in its current form.
