### PR TITLE
chore: ignore OpenTofu working dirs and state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ go.work
 # MkDocs build output and uv-managed venv (docs toolchain)
 site/
 .venv/
+
+# OpenTofu/Terraform working dirs and state. State holds cluster CA keys, an SSH
+# private key and provider tokens in cleartext, so it must never be committable.
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan


### PR DESCRIPTION
`test/e2e-hetzner/` holds 275 untracked local files (~600 MB of provider binaries plus `terraform.tfstate`/`.backup`). Nothing there is tracked and nothing was ignored, so any `git add -A` in this repo stages the lot.

State is the part that matters: it carries the Talos cluster CA keys, an SSH private key and the provider token in cleartext. That is exactly what happened in the now-closed #423, which is why this guard is worth having.

```
**/.terraform/
*.tfstate
*.tfstate.*
*.tfplan
```

Verified with `git check-ignore -v` that all three leaked path shapes are now covered, that the repo tracks no `.tf`/state files the rules could shadow, and that all 275 files in that directory are `.terraform/` or state — so nothing of anyone's own source becomes invisible.