### PR TITLE
ci(release): skip the snapshot build on release commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,12 @@ concurrency:
 jobs:
   versions:
     name: Versions
+    # The release-please merge commit is followed seconds later by its own
+    # `release: published` run, which builds the same tree — skip the snapshot
+    # build for it and let the release do the work.
+    if: >-
+      ${{ github.event_name == 'release'
+        || !startsWith(github.event.head_commit.message, 'chore(main): release') }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -44,6 +50,9 @@ jobs:
   release:
     name: Release
     needs: versions
+    if: >-
+      ${{ github.event_name == 'release'
+        || !startsWith(github.event.head_commit.message, 'chore(main): release') }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Pilot for an org-wide change — if this behaves as expected on the next release, the same two lines go into the other 13 repos whose `release.yaml` has both a `push: main` and a `release: published` trigger.

## The problem

A release-please merge is an ordinary push to `main`, so `release.yaml` fired twice for one release: once for the push, and again seconds later for the `release: published` event that release-please raises on the *same commit*. Two multi-arch builds of identical source, each with SBOM generation and cosign signing.

Confirmed on the last release, [494cd5f](https://github.com/home-operations/tuppr/commit/494cd5fe265095c5ba003fdb2c3f71db9f7ccdf6) (`chore(main): release 0.4.1`):

```
RUN release  Release  success
RUN push     Release  success     <- this one
RUN push     Lint / Tests / Docs  success
```

## The fix

Gate the push path on the commit not being the release commit, so only the release event builds it:

```yaml
if: >-
  ${{ github.event_name == 'release'
    || !startsWith(github.event.head_commit.message, 'chore(main): release') }}
```

**Why the commit subject and not `paths-ignore`.** The obvious alternative is adding `.release-please-manifest.json` and `charts/**` to the push `paths-ignore`. That works here but does not generalise: release-please stamps a different set of files per repo — `Chart.yaml` in this one, `package.json` in talosctl-cluster-action, `editors/**` and `.claude-plugin/**` in yayamlls — so each repo would need a bespoke ignore list that silently stops working the moment `extra-files` changes. The commit subject is uniform. I verified it across all 15 org repos with release history: every release merge is a squash (single parent) with the subject `chore(main): release <version> (#N)`.

**Why a folded scalar.** The expression contains a colon-space inside `chore(main): release`. As a plain YAML scalar that is read as a mapping, and the *entire workflow file* fails to parse — actionlint catches it as `could not parse as YAML`. `>-` avoids both that and an over-long line.

The guard is on both `versions` and `release`. Gating `versions` alone would be enough today, since a skipped dependency skips its dependents, but the expensive job carrying its own guard means a future `needs:` change cannot silently re-enable the double build.

## Knock-on effects, both intended

- `ghcr.io/home-operations/tuppr:main` is no longer re-pushed for the release commit, so it keeps pointing at the last functional-change commit. The image content is identical — the release commit only touches `CHANGELOG.md`, the manifest, and `Chart.yaml`, none of which reach the build — the only difference is a one-commit-older `REVISION` label.
- Cache warming is unaffected. The release build still finds a warm cache, because each commit that went into the release warmed it on its own push. The skipped build was re-warming an already-warm cache.

## Verification

`actionlint` clean, `zizmor` clean (`No findings to report`), and the file still parses with the expression intact (`yq` reads both `if:` values back).

The behavioural test needs a real release: with this merged, merging release PR #419 should show exactly one `Release` run for that commit, from the `release` event, with no `push` one. That is the check to make before fanning this out.
