### PR TITLE
feat(chart): add deploymentAnnotations value

### DIFF
--- a/charts/tuppr/README.md
+++ b/charts/tuppr/README.md
@@ -46,6 +46,7 @@ Kubernetes: `>=1.25.0-0`
 | controller.logLevel | string | `"debug"` | Controller log level: info or debug. |
 | controller.metrics.annotations | object | `{}` | Annotations for the metrics Service. |
 | controller.metrics.port | int | `8081` | Operational port: /metrics plus the /healthz and /readyz probes (plain HTTP; always on — restrict with a NetworkPolicy rather than disabling). |
+| deploymentAnnotations | object | `{}` | Annotations added to the Deployment (e.g. for reloader). |
 | env | list | `[]` | Extra environment variables passed to the container. |
 | fullnameOverride | string | `""` | Override the full release name. |
 | image.digest | string | `""` | Pin the image by digest (sha256:…); when set, overrides the tag. |

--- a/charts/tuppr/templates/deployment.tpl
+++ b/charts/tuppr/templates/deployment.tpl
@@ -12,6 +12,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "tuppr.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/tuppr/tests/deployment_test.yaml
+++ b/charts/tuppr/tests/deployment_test.yaml
@@ -32,6 +32,20 @@ tests:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/home-operations/tuppr@sha256:abc123
 
+  - it: should set deployment annotations from values
+    set:
+      deploymentAnnotations:
+        reloader.stakater.com/auto: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+
+  - it: should not render deployment annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
   - it: should set replicas from values
     set:
       replicaCount: 3

--- a/charts/tuppr/values.schema.json
+++ b/charts/tuppr/values.schema.json
@@ -53,6 +53,12 @@
       "title": "controller",
       "type": "object"
     },
+    "deploymentAnnotations": {
+      "description": "Annotations added to the Deployment (e.g. for reloader).",
+      "required": [],
+      "title": "deploymentAnnotations",
+      "type": "object"
+    },
     "env": {
       "description": "Extra environment variables passed to the container.",
       "items": {

--- a/charts/tuppr/values.yaml
+++ b/charts/tuppr/values.yaml
@@ -43,6 +43,9 @@ talosServiceAccount:
   # e2e/kind) and provide that Secret yourself.
   create: true
 
+# -- Annotations added to the Deployment (e.g. for reloader).
+deploymentAnnotations: {}
+
 # -- Annotations added to the pod.
 podAnnotations: {}
 # -- Labels added to the pod.


### PR DESCRIPTION
Adds a `deploymentAnnotations` value to the Helm chart, rendered as `metadata.annotations` on the Deployment. Useful for controllers like [reloader](https://github.com/stakater/Reloader) that key off Deployment annotations.

- `values.yaml`: new `deploymentAnnotations: {}` alongside `podAnnotations`
- `deployment.tpl`: renders the annotations block only when set
- unit tests for both the set and default (absent) cases
- README and `values.schema.json` regenerated via `mise run helm-docs`

Closes #432