### PR TITLE
fix(ci): key the lint cache on the toolchain and drop the prefix fallback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,12 +257,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-
 
+      # This cache holds analyzer facts (staticcheck's "does this call
+      # return?"), so a stale or partial entry does not just cost time -- it
+      # turns checks like SA5011 into false positives on untouched code. Hence
+      # the lock file in the key, so a golangci-lint or Go bump starts fresh
+      # rather than inheriting the previous binary's facts, and no restore-keys:
+      # a miss must start cold instead of falling back to the newest entry
+      # under the prefix, which is how one bad entry outlives its own commit.
       - name: Cache golangci-lint
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint
-          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
-          restore-keys: ${{ runner.os }}-golangci-lint-
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml', '.mise/mise.lock') }}
 
       - name: Run linter
         run: mise run lint
@@ -404,12 +410,15 @@ jobs:
     runs-on: ubuntu-24.04
     permissions: {}
     steps:
+      # cancelled counts as failed: !cancelled() above still runs this job when
+      # individual needs were cancelled but the run was not, and a required job
+      # that never reached a verdict must not clear the merge gate.
       - name: Any jobs failed?
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
           exit 1
 
       - name: All jobs passed or skipped?
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: |
           echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"


### PR DESCRIPTION
Ports the two `ci.yaml` fixes from home-operations/miroir#374. Both defects were present here verbatim.

## The golangci-lint cache could poison itself

That cache holds analyzer facts (staticcheck's "does this call return?"), so a stale or partial entry does not just cost time: it turns checks like SA5011 into false positives on code the commit never touched. miroir hit exactly that in its merge queue, twice, on byte-identical trees, with a cache key of the same shape as this one.

The key hashed only `go.sum` and `.golangci.yml`, so a bad entry survives any commit touching neither, and the bare-prefix `restore-keys` hands it to every subsequent run until GitHub's 7-day eviction.

- the key now covers `.mise/mise.lock`, so a golangci-lint or Go bump starts fresh instead of handing a new binary the old one's facts
- `restore-keys` is gone: a miss must start cold rather than fall back to the newest entry under the prefix

Exact hits stay the norm, since the three hashed inputs are stable across most PRs. When one does change, a cold cache is the correct outcome.

## `cancelled` did not fail the merge gate

`status` runs under `if: !cancelled()`, which still executes when individual `needs` were cancelled but the run as a whole was not. `needs.*.result` then contains `cancelled`, not `failure`, so `Any jobs failed?` was skipped and `All jobs passed or skipped?` exited 0. Branch protection saw `Build Success` green even though a required job never produced a verdict.

Verified: `actionlint` and `zizmor` clean.

miroir's PR also carried Go-side fixes; none of them apply here. The `Eventf` format-string bug in particular has no counterpart, since every call site in `internal/controller/` passes a literal format with its args.
