### PR TITLE
ci(e2e): adopt talosctl-cluster-action v0.1.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,9 +197,10 @@ jobs:
       - name: Create cluster
         id: cluster
         background: true
-        uses: home-operations/talosctl-cluster-action@97d173e2efba3ec61abbfdf0fbd78ed848608190 # v0.1.4
+        uses: home-operations/talosctl-cluster-action@42a2d1c476f87245e2d1882ec825fb31368b9686 # v0.1.6
         with:
           config: test/e2e-qemu/${{ matrix.leg }}.yaml
+          cache: true
 
       - name: Download the image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/test/e2e-qemu/1cp-0w.yaml
+++ b/test/e2e-qemu/1cp-0w.yaml
@@ -18,10 +18,6 @@ spec:
     talos-version: v1.13.5
     disks:
       - virtio:10GiB
-  network:
-    # Explicit because patches/registry.yaml hardcodes the gateway, the first
-    # address of this range. It is also talosctl's default.
-    cidr: 10.5.0.0/24
   config-patches:
     cluster: ["@patches/registry.yaml"]
     controlplanes: ["@patches/talos-api-access.yaml"]

--- a/test/e2e-qemu/1cp-1w.yaml
+++ b/test/e2e-qemu/1cp-1w.yaml
@@ -16,10 +16,6 @@ spec:
     talos-version: v1.13.5
     disks:
       - virtio:10GiB
-  network:
-    # Explicit because patches/registry.yaml hardcodes the gateway, the first
-    # address of this range. It is also talosctl's default.
-    cidr: 10.5.0.0/24
   config-patches:
     cluster: ["@patches/registry.yaml"]
     controlplanes: ["@patches/talos-api-access.yaml"]

--- a/test/e2e-qemu/3cp-0w.yaml
+++ b/test/e2e-qemu/3cp-0w.yaml
@@ -21,10 +21,6 @@ spec:
     talos-version: v1.13.5
     disks:
       - virtio:10GiB
-  network:
-    # Explicit because patches/registry.yaml hardcodes the gateway, the first
-    # address of this range. It is also talosctl's default.
-    cidr: 10.5.0.0/24
   config-patches:
     cluster: ["@patches/registry.yaml"]
     controlplanes: ["@patches/talos-api-access.yaml"]

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -95,8 +95,9 @@ which `image.sh` has no way to reach.
 
 Each leg still runs its own registry on the runner, so the image never crosses the
 internet. The nodes reach it as `registry.e2e`, which the mirror in
-`patches/registry.yaml` points at port 5000 on the QEMU bridge gateway. That mirror
-entry is inert for a local run, where nothing references `registry.e2e`.
+`patches/registry.yaml` points at port 5000 on the QEMU bridge gateway through the
+action's `${GATEWAY}` substitution. That mirror entry is CI-only: a local run has no
+substitution and nothing references `registry.e2e` anyway, so leave the patch out.
 
 ## How the chart is installed
 

--- a/test/e2e-qemu/patches/registry.yaml
+++ b/test/e2e-qemu/patches/registry.yaml
@@ -1,11 +1,11 @@
 # CI runs a plain-HTTP registry on the runner and pushes the controller image there,
-# so the nodes pull it over the QEMU bridge instead of from the internet. 10.5.0.1 is
-# the bridge gateway, the first address of the spec.network.cidr every leg declares;
-# a leg that changes that range has to change this with it. Inert for a local run:
-# nothing resolves registry.e2e unless CONTROLLER_IMAGE names it.
+# so the nodes pull it over the QEMU bridge instead of from the internet. The action
+# substitutes ${GATEWAY} with the bridge gateway, so the patch follows whatever CIDR
+# a leg picks. Only the action substitutes: a local run must not pass this patch raw
+# (and has no reason to; nothing resolves registry.e2e unless CONTROLLER_IMAGE names it).
 machine:
   registries:
     mirrors:
       registry.e2e:
         endpoints:
-          - http://10.5.0.1:5000
+          - http://${GATEWAY}:5000


### PR DESCRIPTION
Bumps the e2e cluster action pin from v0.1.4 to [v0.1.6](https://github.com/home-operations/talosctl-cluster-action/releases/tag/v0.1.6) and adopts two of its features:

- **`cache: true`** — the Image Factory boot assets (`~/.talos/cache`) ride the Actions cache, keyed on Talos version/schematic/presets/factory URL, so only the first run per combination downloads boot media. Safe by construction: talosctl's own lookup is by full source URL, so a hit cannot serve wrong bytes.
- **`${GATEWAY}` substitution** — `patches/registry.yaml` no longer hardcodes `10.5.0.1`. The explicit `network.cidr` in the three leg documents existed only to keep that hardcode honest, so it is gone too; the legs are back on talosctl's default. The patch stays inert for local runs, which never passed it anyway (nothing resolves `registry.e2e` there).

The third v0.1.6 feature, the maintenance-preset API wait, does not apply here — no leg uses the maintenance preset.