### PR TITLE
fix(status): keep conditions and history truthful

### DIFF
--- a/api/v1alpha1/kubernetesupgrade_types.go
+++ b/api/v1alpha1/kubernetesupgrade_types.go
@@ -109,8 +109,14 @@ type KubernetesUpgradeStatus struct {
 
 	// History records past version transitions on this CR, newest first
 	// +optional
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=3
 	History []UpgradeHistoryEntry `json:"history,omitempty"`
+
+	// CompletionCycles counts Completed→Pending re-entries: a completed run
+	// re-opened because a node still lags the target version. Bounds restart
+	// loops; reset by spec changes and the reset annotation.
+	// +optional
+	CompletionCycles int `json:"completionCycles,omitempty"`
 }
 
 // UpgradeHistoryEntry records a single completed version transition

--- a/api/v1alpha1/talosupgrade_types.go
+++ b/api/v1alpha1/talosupgrade_types.go
@@ -282,8 +282,14 @@ type TalosUpgradeStatus struct {
 
 	// History records past version transitions on this CR, newest first
 	// +optional
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=3
 	History []TalosUpgradeHistoryEntry `json:"history,omitempty"`
+
+	// CompletionCycles counts Completed→Pending re-entries: a completed run
+	// re-opened because a matching node still needs the target version. Bounds
+	// restart loops; reset by spec changes and the reset annotation.
+	// +optional
+	CompletionCycles int `json:"completionCycles,omitempty"`
 
 	// PreHookIndex is the index of the next pre-hook to run.
 	// Equals len(spec.hooks.pre) once all pre-hooks are done.

--- a/config/crd/bases/tuppr.home-operations.com_kubernetesupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_kubernetesupgrades.yaml
@@ -245,6 +245,12 @@ spec:
                   phase
                 format: date-time
                 type: string
+              completionCycles:
+                description: |-
+                  CompletionCycles counts Completed→Pending re-entries: a completed run
+                  re-opened because a node still lags the target version. Bounds restart
+                  loops; reset by spec changes and the reset annotation.
+                type: integer
               conditions:
                 description: Conditions report the upgrade's "Progressing" and "Ready"
                   status.
@@ -368,7 +374,7 @@ spec:
                   - startedAt
                   - toVersion
                   type: object
-                maxItems: 10
+                maxItems: 3
                 type: array
               jobName:
                 description: JobName is the name of the job handling the upgrade

--- a/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
@@ -4970,6 +4970,12 @@ spec:
                 items:
                   type: string
                 type: array
+              completionCycles:
+                description: |-
+                  CompletionCycles counts Completed→Pending re-entries: a completed run
+                  re-opened because a matching node still needs the target version. Bounds
+                  restart loops; reset by spec changes and the reset annotation.
+                type: integer
               conditions:
                 description: Conditions report the upgrade's "Progressing" and "Ready"
                   status.
@@ -5118,7 +5124,7 @@ spec:
                   - startedAt
                   - toVersion
                   type: object
-                maxItems: 10
+                maxItems: 3
                 type: array
               lastUpdated:
                 description: LastUpdated timestamp of last status update

--- a/docs/kubernetes-upgrades.md
+++ b/docs/kubernetes-upgrades.md
@@ -47,8 +47,9 @@ kubectl edit kubernetesupgrade kubernetes
 ## History and status
 
 Each run records `.status.startedAt` / `.status.completedAt`, and past runs are
-kept in `.status.history[]` (newest first, capped at 10). Phase transitions are
-emitted as Kubernetes Events:
+kept in `.status.history[]` (newest first, capped at 3). A run that did no work
+(e.g. a spec re-apply with the cluster already at target) is not recorded.
+Phase transitions are emitted as Kubernetes Events:
 
 ```bash
 kubectl describe kubernetesupgrade kubernetes

--- a/internal/controller/kubernetesupgrade/annotations.go
+++ b/internal/controller/kubernetesupgrade/annotations.go
@@ -65,13 +65,15 @@ func (r *Reconciler) handleResetAnnotation(ctx context.Context, kubernetesUpgrad
 	}
 
 	if err := r.setPhaseWithUpdates(ctx, kubernetesUpgrade, tupprv1alpha1.JobPhasePending, "", "", "Reset requested via annotation", map[string]any{
-		statusFieldJobName:   "",
-		"retries":            0,
-		statusFieldLastError: "",
+		statusFieldJobName:          "",
+		"retries":                   0,
+		statusFieldLastError:        "",
+		statusFieldCompletionCycles: 0,
 	}); err != nil {
 		logger.Error(err, "Failed to reset status after annotation")
 		return false, err
 	}
+	kubernetesUpgrade.Status.CompletionCycles = 0
 
 	return true, nil
 }
@@ -89,11 +91,13 @@ func (r *Reconciler) handleGenerationChange(ctx context.Context, kubernetesUpgra
 
 	message := fmt.Sprintf("Spec updated to %s, restarting upgrade process", kubernetesUpgrade.Spec.Kubernetes.Version)
 	if err := r.setPhaseWithUpdates(ctx, kubernetesUpgrade, tupprv1alpha1.JobPhasePending, "", "", message, map[string]any{
-		statusFieldJobName:   "",
-		"retries":            0,
-		statusFieldLastError: "",
+		statusFieldJobName:          "",
+		"retries":                   0,
+		statusFieldLastError:        "",
+		statusFieldCompletionCycles: 0,
 	}); err != nil {
 		return false, err
 	}
+	kubernetesUpgrade.Status.CompletionCycles = 0
 	return true, nil
 }

--- a/internal/controller/kubernetesupgrade/audit.go
+++ b/internal/controller/kubernetesupgrade/audit.go
@@ -29,16 +29,21 @@ func applyPhaseAuditFields(status *tupprv1alpha1.KubernetesUpgradeStatus, update
 		}
 		updates["completedAt"] = now
 
-		// A run that never went active (StartedAt unset) did no work, e.g. a
-		// spec re-apply with the cluster already at target. Recording it would
-		// fabricate a zero-duration entry for an upgrade that never happened.
-		if status.StartedAt == nil {
+		// A Completed run that never went active (StartedAt unset) did no
+		// work, e.g. a spec re-apply with the cluster already at target;
+		// recording it would fabricate a zero-duration entry for an upgrade
+		// that never happened. Failed runs are always recorded.
+		if nextPhase == tupprv1alpha1.JobPhaseCompleted && status.StartedAt == nil {
 			return
+		}
+		startedAt := now
+		if status.StartedAt != nil {
+			startedAt = *status.StartedAt
 		}
 		entry := tupprv1alpha1.UpgradeHistoryEntry{
 			FromVersion: status.CurrentVersion,
 			ToVersion:   status.TargetVersion,
-			StartedAt:   *status.StartedAt,
+			StartedAt:   startedAt,
 			CompletedAt: now,
 			Phase:       nextPhase,
 			Retries:     status.Retries,

--- a/internal/controller/kubernetesupgrade/audit.go
+++ b/internal/controller/kubernetesupgrade/audit.go
@@ -29,14 +29,16 @@ func applyPhaseAuditFields(status *tupprv1alpha1.KubernetesUpgradeStatus, update
 		}
 		updates["completedAt"] = now
 
-		startedAt := now
-		if status.StartedAt != nil {
-			startedAt = *status.StartedAt
+		// A run that never went active (StartedAt unset) did no work, e.g. a
+		// spec re-apply with the cluster already at target. Recording it would
+		// fabricate a zero-duration entry for an upgrade that never happened.
+		if status.StartedAt == nil {
+			return
 		}
 		entry := tupprv1alpha1.UpgradeHistoryEntry{
 			FromVersion: status.CurrentVersion,
 			ToVersion:   status.TargetVersion,
-			StartedAt:   startedAt,
+			StartedAt:   *status.StartedAt,
 			CompletedAt: now,
 			Phase:       nextPhase,
 			Retries:     status.Retries,
@@ -57,19 +59,6 @@ func syncLocalAuditFields(status *tupprv1alpha1.KubernetesUpgradeStatus, updates
 			status.History = h
 		}
 	}
-}
-
-// completionCyclesForVersion counts consecutive newest-first Completed entries
-// for the given target version.
-func completionCyclesForVersion(history []tupprv1alpha1.UpgradeHistoryEntry, version string) int {
-	count := 0
-	for _, e := range history {
-		if e.Phase != tupprv1alpha1.JobPhaseCompleted || e.ToVersion != version {
-			break
-		}
-		count++
-	}
-	return count
 }
 
 func (r *Reconciler) emitPhaseEvent(ku *tupprv1alpha1.KubernetesUpgrade, prev, next tupprv1alpha1.JobPhase, message string) {

--- a/internal/controller/kubernetesupgrade/audit_test.go
+++ b/internal/controller/kubernetesupgrade/audit_test.go
@@ -132,6 +132,22 @@ func TestApplyPhaseAuditFields_TerminalTransition(t *testing.T) {
 		}
 	})
 
+	t.Run("terminal without startedAt records no history (no-op run)", func(t *testing.T) {
+		status := tupprv1alpha1.KubernetesUpgradeStatus{
+			Phase:          tupprv1alpha1.JobPhasePending,
+			CurrentVersion: toVer,
+			TargetVersion:  toVer,
+		}
+		updates := map[string]any{}
+		applyPhaseAuditFields(&status, updates, tupprv1alpha1.JobPhaseCompleted, now, "done")
+		if _, ok := updates["history"]; ok {
+			t.Fatal("no-op run must not append history")
+		}
+		if got := updates["completedAt"].(metav1.Time); !got.Equal(&now) {
+			t.Fatalf("want completedAt %v, got %v", now, got)
+		}
+	})
+
 	t.Run("already-terminal does not append duplicate", func(t *testing.T) {
 		status := tupprv1alpha1.KubernetesUpgradeStatus{
 			Phase:     tupprv1alpha1.JobPhaseCompleted,

--- a/internal/controller/kubernetesupgrade/audit_test.go
+++ b/internal/controller/kubernetesupgrade/audit_test.go
@@ -132,7 +132,7 @@ func TestApplyPhaseAuditFields_TerminalTransition(t *testing.T) {
 		}
 	})
 
-	t.Run("terminal without startedAt records no history (no-op run)", func(t *testing.T) {
+	t.Run("Completed without startedAt records no history (no-op run)", func(t *testing.T) {
 		status := tupprv1alpha1.KubernetesUpgradeStatus{
 			Phase:          tupprv1alpha1.JobPhasePending,
 			CurrentVersion: toVer,
@@ -145,6 +145,26 @@ func TestApplyPhaseAuditFields_TerminalTransition(t *testing.T) {
 		}
 		if got := updates["completedAt"].(metav1.Time); !got.Equal(&now) {
 			t.Fatalf("want completedAt %v, got %v", now, got)
+		}
+	})
+
+	t.Run("Failed without startedAt still records history", func(t *testing.T) {
+		status := tupprv1alpha1.KubernetesUpgradeStatus{
+			Phase:         tupprv1alpha1.JobPhasePending,
+			TargetVersion: toVer,
+			LastError:     "no controller node found",
+		}
+		updates := map[string]any{}
+		applyPhaseAuditFields(&status, updates, tupprv1alpha1.JobPhaseFailed, now, "msg")
+		h, ok := updates["history"].([]tupprv1alpha1.UpgradeHistoryEntry)
+		if !ok || len(h) != 1 || h[0].Phase != tupprv1alpha1.JobPhaseFailed {
+			t.Fatalf("want 1 Failed entry, got %+v", updates["history"])
+		}
+		if !h[0].StartedAt.Equal(&now) {
+			t.Fatalf("want startedAt fallback to now, got %v", h[0].StartedAt)
+		}
+		if h[0].LastError != "no controller node found" {
+			t.Fatalf("want LastError preserved, got %q", h[0].LastError)
 		}
 	})
 

--- a/internal/controller/kubernetesupgrade/controller.go
+++ b/internal/controller/kubernetesupgrade/controller.go
@@ -42,17 +42,18 @@ const (
 )
 
 const (
-	appLabelKey               = jobs.AppLabelKey
-	appInstanceLabelKey       = jobs.AppInstanceLabelKey
-	appPartOfLabelKey         = jobs.AppPartOfLabelKey
-	appPartOfTuppr            = jobs.AppPartOfTuppr
-	kubernetesUpgradeAppName  = "kubernetes-upgrade"
-	statusFieldJobName        = "jobName"
-	statusFieldCurrentVersion = "currentVersion"
-	statusFieldTargetVersion  = "targetVersion"
-	statusFieldLastError      = "lastError"
-	targetNodeLabelKey        = jobs.TargetNodeLabelKey
-	upgradeK8sCommand         = "upgrade-k8s"
+	appLabelKey                 = jobs.AppLabelKey
+	appInstanceLabelKey         = jobs.AppInstanceLabelKey
+	appPartOfLabelKey           = jobs.AppPartOfLabelKey
+	appPartOfTuppr              = jobs.AppPartOfTuppr
+	kubernetesUpgradeAppName    = "kubernetes-upgrade"
+	statusFieldJobName          = "jobName"
+	statusFieldCurrentVersion   = "currentVersion"
+	statusFieldTargetVersion    = "targetVersion"
+	statusFieldLastError        = "lastError"
+	statusFieldCompletionCycles = "completionCycles"
+	targetNodeLabelKey          = jobs.TargetNodeLabelKey
+	upgradeK8sCommand           = "upgrade-k8s"
 
 	// Fallback when Reconciler.DefaultEndpoint is unset (tests).
 	defaultKubernetesAPIEndpoint = "https://kubernetes.default.svc.cluster.local:443"

--- a/internal/controller/kubernetesupgrade/controller_test.go
+++ b/internal/controller/kubernetesupgrade/controller_test.go
@@ -562,6 +562,12 @@ func TestK8sReconcile_HandlesJobFailure(t *testing.T) {
 	ku := newKubernetesUpgrade("test-upgrade",
 		withK8sFinalizer,
 		withK8sPhase(tupprv1alpha1.JobPhaseUpgrading),
+		func(ku *tupprv1alpha1.KubernetesUpgrade) {
+			// Entering an active phase always stamps StartedAt; a nil StartedAt
+			// at terminal time means a no-op run and would skip the history entry.
+			started := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+			ku.Status.StartedAt = &started
+		},
 	)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1172,21 +1178,11 @@ func TestK8sReconcile_PendingFromLaggingWorkerStartsUpgrade(t *testing.T) {
 
 func TestK8sReconcile_CompletedCyclesExhaustedTransitionsToFailed(t *testing.T) {
 	scheme := newTestScheme()
-	now := metav1.Now()
-	history := make([]tupprv1alpha1.UpgradeHistoryEntry, upgradeaudit.MaxCompletionCycles)
-	for i := range history {
-		history[i] = tupprv1alpha1.UpgradeHistoryEntry{
-			ToVersion:   testK8sVersion,
-			Phase:       tupprv1alpha1.JobPhaseCompleted,
-			StartedAt:   now,
-			CompletedAt: now,
-		}
-	}
 	ku := newKubernetesUpgrade("test-upgrade",
 		withK8sFinalizer,
 		withK8sPhase(tupprv1alpha1.JobPhaseCompleted),
 		func(ku *tupprv1alpha1.KubernetesUpgrade) {
-			ku.Status.History = history
+			ku.Status.CompletionCycles = upgradeaudit.MaxCompletionCycles
 		},
 	)
 	cpAtTarget := newControllerNodeWithVersion("ctrl-1", testNodeIP, testK8sVersion)
@@ -1204,6 +1200,30 @@ func TestK8sReconcile_CompletedCyclesExhaustedTransitionsToFailed(t *testing.T) 
 	}
 	if !strings.Contains(updated.Status.Message, "never converged") {
 		t.Fatalf("expected Failed message to mention non-convergence, got: %q", updated.Status.Message)
+	}
+}
+
+func TestK8sReconcile_CompletedWithLaggingNodeIncrementsCycles(t *testing.T) {
+	scheme := newTestScheme()
+	ku := newKubernetesUpgrade("test-upgrade",
+		withK8sFinalizer,
+		withK8sPhase(tupprv1alpha1.JobPhaseCompleted),
+	)
+	cpAtTarget := newControllerNodeWithVersion("ctrl-1", testNodeIP, testK8sVersion)
+	workerLagging := newLaggingWorkerNode("10.0.0.5")
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(ku, cpAtTarget, workerLagging).WithStatusSubresource(ku).Build()
+	r := newK8sReconciler(cl, &mockVersionGetter{version: testK8sVersion}, &mockTalosClient{}, &mockHealthChecker{})
+
+	reconcileK8s(t, r, "test-upgrade")
+
+	updated := getK8sUpgrade(t, cl, "test-upgrade")
+	if updated.Status.Phase != tupprv1alpha1.JobPhasePending {
+		t.Fatalf("expected phase Pending after campaign restart, got: %s", updated.Status.Phase)
+	}
+	if updated.Status.CompletionCycles != 1 {
+		t.Fatalf("expected completionCycles=1 after restart, got %d", updated.Status.CompletionCycles)
 	}
 }
 

--- a/internal/controller/kubernetesupgrade/upgrade.go
+++ b/internal/controller/kubernetesupgrade/upgrade.go
@@ -54,7 +54,7 @@ func (r *Reconciler) processUpgrade(ctx context.Context, kubernetesUpgrade *tupp
 		if allUpgraded {
 			return ctrl.Result{RequeueAfter: time.Hour}, nil
 		}
-		cycles := completionCyclesForVersion(kubernetesUpgrade.Status.History, targetVersion)
+		cycles := kubernetesUpgrade.Status.CompletionCycles
 		if cycles >= upgradeaudit.MaxCompletionCycles {
 			message := fmt.Sprintf(
 				"Some nodes never converged to %s after %d completion cycles; add the %s annotation or bump the spec to retry",
@@ -68,10 +68,13 @@ func (r *Reconciler) processUpgrade(ctx context.Context, kubernetesUpgrade *tupp
 			return ctrl.Result{RequeueAfter: time.Hour}, nil
 		}
 		logger.Info("Node lagging target version, restarting campaign", "target", targetVersion, "cycle", cycles+1)
-		if err := r.setPhase(ctx, kubernetesUpgrade, tupprv1alpha1.JobPhasePending, "", "Node lagging target version, restarting upgrade"); err != nil {
+		if err := r.setPhaseWithUpdates(ctx, kubernetesUpgrade, tupprv1alpha1.JobPhasePending, "", "", "Node lagging target version, restarting upgrade", map[string]any{
+			statusFieldCompletionCycles: cycles + 1,
+		}); err != nil {
 			logger.Error(err, "Failed to re-enter Pending after completion")
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
+		kubernetesUpgrade.Status.CompletionCycles = cycles + 1
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}
 

--- a/internal/controller/talosupgrade/annotations.go
+++ b/internal/controller/talosupgrade/annotations.go
@@ -65,18 +65,20 @@ func (r *Reconciler) handleResetAnnotation(ctx context.Context, talosUpgrade *tu
 	}
 
 	if err := r.setPhaseWithUpdates(ctx, talosUpgrade, tupprv1alpha1.JobPhasePending, "", nil, "Reset requested via annotation", map[string]any{
-		statusCompletedNodes: []string{},
-		statusFailedNodes:    []tupprv1alpha1.NodeUpgradeStatus{},
-		statusRebootingNodes: []tupprv1alpha1.NodeRebootStatus{},
-		statusPreHookIndex:   0,
-		statusPostHookIndex:  0,
-		statusPreHookFailed:  false,
-		statusPrePulledNodes: []tupprv1alpha1.PrePulledNode{},
-		statusPrePullFailure: nil,
+		statusCompletedNodes:   []string{},
+		statusFailedNodes:      []tupprv1alpha1.NodeUpgradeStatus{},
+		statusRebootingNodes:   []tupprv1alpha1.NodeRebootStatus{},
+		statusPreHookIndex:     0,
+		statusPostHookIndex:    0,
+		statusPreHookFailed:    false,
+		statusPrePulledNodes:   []tupprv1alpha1.PrePulledNode{},
+		statusPrePullFailure:   nil,
+		statusCompletionCycles: 0,
 	}); err != nil {
 		logger.Error(err, "Failed to reset status after annotation")
 		return false, err
 	}
+	talosUpgrade.Status.CompletionCycles = 0
 	resetRunProgress(&talosUpgrade.Status)
 
 	return true, nil
@@ -93,17 +95,19 @@ func (r *Reconciler) handleGenerationChange(ctx context.Context, talosUpgrade *t
 		"observed", talosUpgrade.Status.ObservedGeneration)
 
 	if err := r.setPhaseWithUpdates(ctx, talosUpgrade, tupprv1alpha1.JobPhasePending, "", nil, "Spec updated, restarting upgrade process", map[string]any{
-		statusCompletedNodes: []string{},
-		statusFailedNodes:    []tupprv1alpha1.NodeUpgradeStatus{},
-		statusRebootingNodes: []tupprv1alpha1.NodeRebootStatus{},
-		statusPreHookIndex:   0,
-		statusPostHookIndex:  0,
-		statusPreHookFailed:  false,
-		statusPrePulledNodes: []tupprv1alpha1.PrePulledNode{},
-		statusPrePullFailure: nil,
+		statusCompletedNodes:   []string{},
+		statusFailedNodes:      []tupprv1alpha1.NodeUpgradeStatus{},
+		statusRebootingNodes:   []tupprv1alpha1.NodeRebootStatus{},
+		statusPreHookIndex:     0,
+		statusPostHookIndex:    0,
+		statusPreHookFailed:    false,
+		statusPrePulledNodes:   []tupprv1alpha1.PrePulledNode{},
+		statusPrePullFailure:   nil,
+		statusCompletionCycles: 0,
 	}); err != nil {
 		return false, err
 	}
+	talosUpgrade.Status.CompletionCycles = 0
 	resetRunProgress(&talosUpgrade.Status)
 	return true, nil
 }

--- a/internal/controller/talosupgrade/audit.go
+++ b/internal/controller/talosupgrade/audit.go
@@ -29,10 +29,13 @@ func applyPhaseAuditFields(status *tupprv1alpha1.TalosUpgradeStatus, updates map
 		}
 		updates["completedAt"] = now
 
-		startedAt := now
-		if status.StartedAt != nil {
-			startedAt = *status.StartedAt
+		// A run that never went active (StartedAt unset) did no work, e.g. a
+		// spec re-apply with every node already at target. Recording it would
+		// fabricate a zero-duration entry claiming nodes the run never touched.
+		if status.StartedAt == nil {
+			return
 		}
+		startedAt := *status.StartedAt
 
 		failedNames := make([]string, 0, len(status.FailedNodes))
 		for _, n := range status.FailedNodes {
@@ -76,19 +79,6 @@ func syncLocalAuditFields(status *tupprv1alpha1.TalosUpgradeStatus, updates map[
 			status.RebootingNodes = s
 		}
 	}
-}
-
-// completionCyclesForVersion counts consecutive newest-first Completed entries
-// for the given target version.
-func completionCyclesForVersion(history []tupprv1alpha1.TalosUpgradeHistoryEntry, version string) int {
-	count := 0
-	for _, e := range history {
-		if e.Phase != tupprv1alpha1.JobPhaseCompleted || e.ToVersion != version {
-			break
-		}
-		count++
-	}
-	return count
 }
 
 func (r *Reconciler) emitPhaseEvent(tu *tupprv1alpha1.TalosUpgrade, prev, next tupprv1alpha1.JobPhase, message string) {

--- a/internal/controller/talosupgrade/audit.go
+++ b/internal/controller/talosupgrade/audit.go
@@ -29,13 +29,17 @@ func applyPhaseAuditFields(status *tupprv1alpha1.TalosUpgradeStatus, updates map
 		}
 		updates["completedAt"] = now
 
-		// A run that never went active (StartedAt unset) did no work, e.g. a
-		// spec re-apply with every node already at target. Recording it would
-		// fabricate a zero-duration entry claiming nodes the run never touched.
-		if status.StartedAt == nil {
+		// A Completed run that never went active (StartedAt unset) did no
+		// work, e.g. a spec re-apply with every node already at target;
+		// recording it would fabricate a zero-duration entry claiming nodes
+		// the run never touched. Failed runs are always recorded.
+		if nextPhase == tupprv1alpha1.JobPhaseCompleted && status.StartedAt == nil {
 			return
 		}
-		startedAt := *status.StartedAt
+		startedAt := now
+		if status.StartedAt != nil {
+			startedAt = *status.StartedAt
+		}
 
 		failedNames := make([]string, 0, len(status.FailedNodes))
 		for _, n := range status.FailedNodes {

--- a/internal/controller/talosupgrade/audit_test.go
+++ b/internal/controller/talosupgrade/audit_test.go
@@ -89,7 +89,7 @@ func TestApplyPhaseAuditFields_Talos(t *testing.T) {
 			},
 		},
 		{
-			name: "terminal without startedAt records no history (no-op run)",
+			name: "Completed without startedAt records no history (no-op run)",
 			status: tupprv1alpha1.TalosUpgradeStatus{
 				Phase:          tupprv1alpha1.JobPhasePending,
 				CompletedNodes: []string{fakeNodeA, fakeNodeB},
@@ -97,6 +97,25 @@ func TestApplyPhaseAuditFields_Talos(t *testing.T) {
 			nextPhase:     tupprv1alpha1.JobPhaseCompleted,
 			targetVersion: fakeTalosVersion,
 			wantCompleted: now,
+		},
+		{
+			name: "Failed without startedAt still records history",
+			status: tupprv1alpha1.TalosUpgradeStatus{
+				Phase: tupprv1alpha1.JobPhasePending,
+			},
+			nextPhase:     tupprv1alpha1.JobPhaseFailed,
+			targetVersion: fakeTalosVersion,
+			wantCompleted: now,
+			wantHistoryOp: func(t *testing.T, updates map[string]any) {
+				t.Helper()
+				h := updates["history"].([]tupprv1alpha1.TalosUpgradeHistoryEntry)
+				if len(h) != 1 || h[0].Phase != tupprv1alpha1.JobPhaseFailed {
+					t.Fatalf("want 1 Failed entry, got %+v", h)
+				}
+				if !h[0].StartedAt.Equal(&now) {
+					t.Fatalf("want startedAt fallback to now, got %v", h[0].StartedAt)
+				}
+			},
 		},
 		{
 			name: "re-entry to Pending clears timestamps",

--- a/internal/controller/talosupgrade/audit_test.go
+++ b/internal/controller/talosupgrade/audit_test.go
@@ -89,6 +89,16 @@ func TestApplyPhaseAuditFields_Talos(t *testing.T) {
 			},
 		},
 		{
+			name: "terminal without startedAt records no history (no-op run)",
+			status: tupprv1alpha1.TalosUpgradeStatus{
+				Phase:          tupprv1alpha1.JobPhasePending,
+				CompletedNodes: []string{fakeNodeA, fakeNodeB},
+			},
+			nextPhase:     tupprv1alpha1.JobPhaseCompleted,
+			targetVersion: fakeTalosVersion,
+			wantCompleted: now,
+		},
+		{
 			name: "re-entry to Pending clears timestamps",
 			status: tupprv1alpha1.TalosUpgradeStatus{
 				Phase:       tupprv1alpha1.JobPhaseCompleted,

--- a/internal/controller/talosupgrade/controller.go
+++ b/internal/controller/talosupgrade/controller.go
@@ -65,6 +65,7 @@ const (
 	statusPostHookIndex      = "postHookIndex"
 	statusPrePulledNodes     = "prePulledNodes"
 	statusPrePullFailure     = "prePullFailure"
+	statusCompletionCycles   = "completionCycles"
 )
 
 // TalosClient defines the interface for Talos operations

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -1114,21 +1114,11 @@ func TestTalosReconcile_OutOfBandUpgradedNodeRecorded(t *testing.T) {
 
 func TestTalosReconcile_CompletedCyclesExhaustedTransitionsToFailed(t *testing.T) {
 	scheme := newTestScheme()
-	now := metav1.Now()
-	history := make([]tupprv1alpha1.TalosUpgradeHistoryEntry, upgradeaudit.MaxCompletionCycles)
-	for i := range history {
-		history[i] = tupprv1alpha1.TalosUpgradeHistoryEntry{
-			ToVersion:   fakeTalosVersion,
-			Phase:       tupprv1alpha1.JobPhaseCompleted,
-			StartedAt:   now,
-			CompletedAt: now,
-		}
-	}
 	tu := newTalosUpgrade(testUpgradeName,
 		withFinalizer,
 		withPhase(tupprv1alpha1.JobPhaseCompleted),
 		func(tu *tupprv1alpha1.TalosUpgrade) {
-			tu.Status.History = history
+			tu.Status.CompletionCycles = upgradeaudit.MaxCompletionCycles
 		},
 	)
 	laggingNode := newNode(fakeNodeA, testNodeIP1)
@@ -1150,6 +1140,34 @@ func TestTalosReconcile_CompletedCyclesExhaustedTransitionsToFailed(t *testing.T
 	}
 	if !strings.Contains(updated.Status.Message, "never converged") {
 		t.Fatalf("expected Failed message to mention non-convergence, got: %q", updated.Status.Message)
+	}
+}
+
+func TestTalosReconcile_CompletedWithLaggingNodeIncrementsCycles(t *testing.T) {
+	scheme := newTestScheme()
+	tu := newTalosUpgrade(testUpgradeName,
+		withFinalizer,
+		withPhase(tupprv1alpha1.JobPhaseCompleted),
+	)
+	laggingNode := newNode(fakeNodeA, testNodeIP1)
+	tc := &mockTalosClient{
+		nodeVersions: map[string]string{testNodeIP1: testV110Talos},
+		installImages: map[string]string{
+			testNodeIP1: "factory.talos.dev/installer:" + testV110Talos,
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu, laggingNode).WithStatusSubresource(tu).Build()
+	r := newTalosReconciler(cl, scheme, tc, &mockHealthChecker{})
+
+	reconcileTalos(t, r, testUpgradeName)
+
+	updated := getTalosUpgrade(t, cl, testUpgradeName)
+	if updated.Status.Phase != tupprv1alpha1.JobPhasePending {
+		t.Fatalf("expected phase Pending after campaign restart, got: %s", updated.Status.Phase)
+	}
+	if updated.Status.CompletionCycles != 1 {
+		t.Fatalf("expected completionCycles=1 after restart, got %d", updated.Status.CompletionCycles)
 	}
 }
 

--- a/internal/controller/talosupgrade/upgrade.go
+++ b/internal/controller/talosupgrade/upgrade.go
@@ -74,7 +74,7 @@ func (r *Reconciler) processUpgrade(ctx context.Context, talosUpgrade *tupprv1al
 			return ctrl.Result{RequeueAfter: time.Hour}, nil
 		}
 		targetVersion := talosUpgrade.Spec.Talos.Version
-		cycles := completionCyclesForVersion(talosUpgrade.Status.History, targetVersion)
+		cycles := talosUpgrade.Status.CompletionCycles
 		if cycles >= upgradeaudit.MaxCompletionCycles {
 			message := fmt.Sprintf(
 				"Node(s) never converged to %s after %d completion cycles; add the %s annotation or bump the spec to retry",
@@ -89,18 +89,20 @@ func (r *Reconciler) processUpgrade(ctx context.Context, talosUpgrade *tupprv1al
 		}
 		logger.Info("Node detected requiring upgrade after completion, restarting campaign", "node", nextNodes[0], "cycle", cycles+1)
 		if err := r.setPhaseWithUpdates(ctx, talosUpgrade, tupprv1alpha1.JobPhasePending, "", nil, "New node detected, restarting upgrade", map[string]any{
-			statusCompletedNodes: []string{},
-			statusFailedNodes:    []tupprv1alpha1.NodeUpgradeStatus{},
-			statusRebootingNodes: []tupprv1alpha1.NodeRebootStatus{},
-			statusPreHookIndex:   0,
-			statusPostHookIndex:  0,
-			statusPreHookFailed:  false,
-			statusPrePulledNodes: []tupprv1alpha1.PrePulledNode{},
-			statusPrePullFailure: nil,
+			statusCompletedNodes:   []string{},
+			statusFailedNodes:      []tupprv1alpha1.NodeUpgradeStatus{},
+			statusRebootingNodes:   []tupprv1alpha1.NodeRebootStatus{},
+			statusPreHookIndex:     0,
+			statusPostHookIndex:    0,
+			statusPreHookFailed:    false,
+			statusPrePulledNodes:   []tupprv1alpha1.PrePulledNode{},
+			statusPrePullFailure:   nil,
+			statusCompletionCycles: cycles + 1,
 		}); err != nil {
 			logger.Error(err, "Failed to re-enter Pending after completion")
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
+		talosUpgrade.Status.CompletionCycles = cycles + 1
 		resetRunProgress(&talosUpgrade.Status)
 		return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 	}

--- a/internal/controller/upgradeaudit/conditions.go
+++ b/internal/controller/upgradeaudit/conditions.go
@@ -56,7 +56,9 @@ const (
 )
 
 // ApplyConditions sets Progressing and Ready for the given phase. Empty reason
-// defaults to the phase name.
+// defaults to the phase name. Ready is False until the CR is first observed
+// and while the phase is Failed, so `kubectl wait` and kstatus-style health
+// checks see a failed upgrade as not ready.
 func ApplyConditions(existing []metav1.Condition, phase tupprv1alpha1.JobPhase, reason, message string, observedGeneration int64) []metav1.Condition {
 	initialized := true
 	if reason == "" {
@@ -85,7 +87,7 @@ func ApplyConditions(existing []metav1.Condition, phase tupprv1alpha1.JobPhase, 
 		Message:            message,
 		ObservedGeneration: observedGeneration,
 	}
-	if initialized {
+	if initialized && phase != tupprv1alpha1.JobPhaseFailed {
 		ready.Status = metav1.ConditionTrue
 	}
 

--- a/internal/controller/upgradeaudit/conditions_test.go
+++ b/internal/controller/upgradeaudit/conditions_test.go
@@ -57,7 +57,6 @@ func TestApplyConditions_ReadyOnceAccepted(t *testing.T) {
 	for _, phase := range []tupprv1alpha1.JobPhase{
 		tupprv1alpha1.JobPhasePending,
 		tupprv1alpha1.JobPhaseUpgrading,
-		tupprv1alpha1.JobPhaseFailed,
 	} {
 		t.Run(string(phase), func(t *testing.T) {
 			conds := ApplyConditions(nil, phase, "", "msg", 1)
@@ -66,6 +65,22 @@ func TestApplyConditions_ReadyOnceAccepted(t *testing.T) {
 				t.Fatalf("want Ready=True, got %+v", r)
 			}
 		})
+	}
+}
+
+func TestApplyConditions_ReadyFalseOnFailed(t *testing.T) {
+	conds := ApplyConditions(nil, tupprv1alpha1.JobPhaseFailed, "", "boom", 1)
+	r := findCond(conds, tupprv1alpha1.ConditionTypeReady)
+	if r == nil || r.Status != metav1.ConditionFalse {
+		t.Fatalf("want Ready=False on Failed, got %+v", r)
+	}
+	if r.Reason != ReasonFailed {
+		t.Fatalf("want Reason=%s, got %s", ReasonFailed, r.Reason)
+	}
+
+	recovered := ApplyConditions(conds, tupprv1alpha1.JobPhaseCompleted, "", "done", 2)
+	if r := findCond(recovered, tupprv1alpha1.ConditionTypeReady); r == nil || r.Status != metav1.ConditionTrue {
+		t.Fatalf("want Ready=True again after recovery, got %+v", r)
 	}
 }
 

--- a/internal/controller/upgradeaudit/upgradeaudit.go
+++ b/internal/controller/upgradeaudit/upgradeaudit.go
@@ -1,10 +1,9 @@
 package upgradeaudit
 
-const HistoryMaxEntries = 10
+const HistoryMaxEntries = 3
 
-// MaxCompletionCycles caps Completed→Pending re-entries before the run is
-// marked Failed. Each cycle adds one history entry, so this must stay below
-// HistoryMaxEntries.
+// MaxCompletionCycles caps Completed→Pending re-entries (tracked in
+// status.completionCycles) before the run is marked Failed.
 const MaxCompletionCycles = 5
 
 func PrependHistory[T any](history []T, entry T, limit int) []T {


### PR DESCRIPTION
## Summary

Three related status fixes, found while reviewing the live `TalosUpgrade`/`KubernetesUpgrade` CRs on a real cluster.

### Ready is no longer True on Failed
`ApplyConditions` set Ready=True for every initialized phase, including `Failed` — the live CR showed Ready's `lastTransitionTime` stuck at first reconcile, straight through a failed run. Ready now goes False when the phase is Failed (and flips back on recovery), so `kubectl wait --for=condition=Ready` and Flux/kstatus health checks actually see failures. Progressing is unchanged.

### No-op runs no longer fabricate history
A generation bump with everything already at target goes Pending→Completed without ever entering an active phase, so `StartedAt` was never stamped. The terminal transition then recorded a zero-duration entry with `startedAt == completedAt`, listing `completedNodes` the run never touched (the live CR had three identical v1.13.5 "upgrades", plus a `toVersion: ""` genesis entry on the KubernetesUpgrade). Terminal transitions now skip the history append when `StartedAt` is nil; `completedAt` and the idempotency guard are unchanged.

### Completion-cycle guard moves off the history list
`completionCyclesForVersion` counted consecutive Completed history entries — which included the fabricated no-op entries above. Failure mode: five benign spec touches on one version, then a genuinely new/reinstalled node appears, and the guard instantly marks the run `Failed: never converged` without a single attempt. The guard now uses a dedicated `status.completionCycles` counter, incremented only on real Completed→Pending campaign restarts, reset by spec changes and the reset annotation (both already documented as the retry escape hatches).

### History capped at 3 (was 10)
Decoupling the cycle guard from history removes the constraint that the cap stay above `MaxCompletionCycles`. `maxItems` drops to 3 in the CRD schema; existing objects with longer history are fine — CRD validation ratcheting skips unchanged fields, and the next real terminal transition trims the list.

## Testing

- `mise run test` — unit suites pass, including new cases: Ready=False on Failed (+recovery), no-op terminal skips history (both CRDs), campaign restart increments `completionCycles` (both controllers)
- `mise run test-integration` — 16/16 specs pass under envtest