### PR TITLE
ci: update shared actions and use self-repository syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
   docs:
     if: ${{ github.event_name != 'push' }}
     name: Docs
-    uses: ./.github/workflows/docs.yaml
+    uses: $/.github/workflows/docs.yaml
     permissions:
       contents: read
     with:
@@ -427,7 +427,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Build docs site
-        uses: home-operations/.github/actions/docs-build@d55d4551bf9ad29becda40b66792d94892a6307c # docs-build-1.0.0
+        uses: home-operations/.github/actions/docs-build@4f44306d499ec70355fae5540103c2033955fc2c # docs-build-v1.0.1
         with:
           deploy: ${{ inputs.deploy }}
 

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   docs:
     name: Docs
-    uses: ./.github/workflows/docs.yaml
+    uses: $/.github/workflows/docs.yaml
     permissions:
       contents: read
       pages: write

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -746,22 +746,37 @@ version = "1.29.0"
 backend = "aqua:zizmorcore/zizmor"
 
 [tools.zizmor."platforms.linux-arm64"]
+checksum = "sha256:415eaa7c0a06479a701b8e44a3e812c1047decc848ec4bede7bd6bbf49f22d20"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263143"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-arm64-musl"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64"]
+checksum = "sha256:dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263145"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.linux-x64-musl"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-arm64"]
+checksum = "sha256:720322fade9e83a9c7953944c438f2ba942636b86b96a8f0e6b15ce94c8a6b6f"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263141"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-x64"]
+checksum = "sha256:648b72ab9941a7f2a8d65d7b68a8e76cef789538c8df3a3950384d38423375b0"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263144"
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.windows-x64"]
+checksum = "sha256:68a6bc6888f10bf0d53658c75885e7c1b7a0588d4c1fbc3f0ca280ad7324bf06"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/498263142"
 provenance = "github-attestations"


### PR DESCRIPTION
Bump `home-operations/.github/actions/workflow-lint` from 1.0.0 to v1.0.2.

v1.0.1 pins tool versions and v1.0.2 makes actionlint ignore its false errors on GitHub's new `$/` self-repository `uses:` syntax, so workflows adopting `$/` lint clean.

Also bumps `docs-build` from 1.0.0 to v1.0.1.

Switch same-repository `uses:` references from `./` to the `$/` self-repository syntax ([changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)). `$/` resolves to this repository at the exact commit that is running, works everywhere `./` does, and is now the recommended form; the bumped workflow-lint v1.0.2 is what makes it lint clean.