### PR TITLE
feat: emit health check events on upgrade CRs

### DIFF
--- a/docs/talos-upgrades.md
+++ b/docs/talos-upgrades.md
@@ -60,6 +60,11 @@ spec:
       expr: status.ceph.health in ["HEALTH_OK"]
 ```
 
+Each check attempt is emitted as Events on the resource (`HealthChecksStarted`,
+then `HealthChecksPassed` or a `HealthChecksFailed` warning), so a run waiting
+on failing checks is visible in `kubectl describe`. With pre-hooks configured,
+inter-batch checks are [suppressed](#prepost-upgrade-hooks) and emit no Events.
+
 Health checks are also available on [`KubernetesUpgrade`](kubernetes-upgrades.md).
 
 ## Policy

--- a/internal/controller/kubernetesupgrade/audit.go
+++ b/internal/controller/kubernetesupgrade/audit.go
@@ -1,6 +1,8 @@
 package kubernetesupgrade
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -64,6 +66,28 @@ func syncLocalAuditFields(status *tupprv1alpha1.KubernetesUpgradeStatus, updates
 			status.History = h
 		}
 	}
+}
+
+// runHealthChecks wraps CheckHealth with start/result Events. CheckHealth
+// blocks polling until the checks pass or time out, and the HealthChecking
+// phase is only written after it returns, so the started event is the only
+// signal that a (possibly minutes-long) check attempt is in progress.
+func (r *Reconciler) runHealthChecks(ctx context.Context, ku *tupprv1alpha1.KubernetesUpgrade) error {
+	emit := r.Recorder != nil && len(ku.Spec.HealthChecks) > 0
+	if emit {
+		r.Recorder.Eventf(ku, corev1.EventTypeNormal, "HealthChecksStarted",
+			"Running %d health check(s)", len(ku.Spec.HealthChecks))
+	}
+	checkErr := r.HealthChecker.CheckHealth(ctx, ku.Spec.HealthChecks)
+	if emit {
+		if checkErr != nil {
+			r.Recorder.Event(ku, corev1.EventTypeWarning, "HealthChecksFailed", checkErr.Error())
+		} else {
+			r.Recorder.Eventf(ku, corev1.EventTypeNormal, "HealthChecksPassed",
+				"All %d health check(s) passed", len(ku.Spec.HealthChecks))
+		}
+	}
+	return checkErr
 }
 
 func (r *Reconciler) emitPhaseEvent(ku *tupprv1alpha1.KubernetesUpgrade, prev, next tupprv1alpha1.JobPhase, message string) {

--- a/internal/controller/kubernetesupgrade/audit_test.go
+++ b/internal/controller/kubernetesupgrade/audit_test.go
@@ -2,6 +2,7 @@ package kubernetesupgrade
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -391,5 +392,69 @@ func TestEmitPhaseEvent_SkipsIdenticalPhase(t *testing.T) {
 	case ev := <-recorder.Events:
 		t.Fatalf("did not expect an event, got %q", ev)
 	default:
+	}
+}
+
+func TestRunHealthChecks_K8s_EmitsEvents(t *testing.T) {
+	check := tupprv1alpha1.HealthCheckSpec{APIVersion: "v1", Kind: "Node", Expr: "status != null"}
+	tests := []struct {
+		name       string
+		checks     []tupprv1alpha1.HealthCheckSpec
+		checkErr   error
+		wantEvents []string
+	}{
+		{
+			name:       "pass emits started and passed",
+			checks:     []tupprv1alpha1.HealthCheckSpec{check},
+			wantEvents: []string{"HealthChecksStarted", "HealthChecksPassed"},
+		},
+		{
+			name:       "failure emits started and warning",
+			checks:     []tupprv1alpha1.HealthCheckSpec{check},
+			checkErr:   errors.New("cluster not healthy"),
+			wantEvents: []string{"HealthChecksStarted", "HealthChecksFailed"},
+		},
+		{
+			name: "no configured checks emits nothing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ku := newKubernetesUpgrade("test", func(ku *tupprv1alpha1.KubernetesUpgrade) {
+				ku.Spec.HealthChecks = tt.checks
+			})
+			recorder := record.NewFakeRecorder(4)
+			r := &Reconciler{Recorder: recorder, HealthChecker: &mockHealthChecker{err: tt.checkErr}}
+
+			if err := r.runHealthChecks(context.Background(), ku); !errors.Is(err, tt.checkErr) {
+				t.Fatalf("want checker error %v, got %v", tt.checkErr, err)
+			}
+
+			for _, want := range tt.wantEvents {
+				select {
+				case ev := <-recorder.Events:
+					if !strings.Contains(ev, want) {
+						t.Fatalf("want %s event, got %q", want, ev)
+					}
+				default:
+					t.Fatalf("missing %s event", want)
+				}
+			}
+			select {
+			case ev := <-recorder.Events:
+				t.Fatalf("unexpected extra event %q", ev)
+			default:
+			}
+		})
+	}
+}
+
+func TestRunHealthChecks_K8s_NoRecorderIsSafe(t *testing.T) {
+	ku := newKubernetesUpgrade("test", func(ku *tupprv1alpha1.KubernetesUpgrade) {
+		ku.Spec.HealthChecks = []tupprv1alpha1.HealthCheckSpec{{APIVersion: "v1", Kind: "Node", Expr: "status != null"}}
+	})
+	r := &Reconciler{HealthChecker: &mockHealthChecker{}}
+	if err := r.runHealthChecks(context.Background(), ku); err != nil {
+		t.Fatalf("runHealthChecks without recorder must not fail: %v", err)
 	}
 }

--- a/internal/controller/kubernetesupgrade/upgrade.go
+++ b/internal/controller/kubernetesupgrade/upgrade.go
@@ -136,7 +136,7 @@ func (r *Reconciler) processUpgrade(ctx context.Context, kubernetesUpgrade *tupp
 
 	logger.Info("Kubernetes upgrade needed", "current", currentVersion, "target", targetVersion)
 
-	checkErr := r.HealthChecker.CheckHealth(ctx, kubernetesUpgrade.Spec.HealthChecks)
+	checkErr := r.runHealthChecks(ctx, kubernetesUpgrade)
 	message := "Running health checks"
 	if checkErr != nil {
 		message = fmt.Sprintf("Waiting for health checks: %s", checkErr.Error())

--- a/internal/controller/talosupgrade/audit.go
+++ b/internal/controller/talosupgrade/audit.go
@@ -1,6 +1,8 @@
 package talosupgrade
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -83,6 +85,28 @@ func syncLocalAuditFields(status *tupprv1alpha1.TalosUpgradeStatus, updates map[
 			status.RebootingNodes = s
 		}
 	}
+}
+
+// runHealthChecks wraps CheckHealth with start/result Events. CheckHealth
+// blocks polling until the checks pass or time out, and the HealthChecking
+// phase is only written after it returns, so the started event is the only
+// signal that a (possibly minutes-long) check attempt is in progress.
+func (r *Reconciler) runHealthChecks(ctx context.Context, tu *tupprv1alpha1.TalosUpgrade) error {
+	emit := r.Recorder != nil && len(tu.Spec.HealthChecks) > 0
+	if emit {
+		r.Recorder.Eventf(tu, corev1.EventTypeNormal, "HealthChecksStarted",
+			"Running %d health check(s)", len(tu.Spec.HealthChecks))
+	}
+	checkErr := r.HealthChecker.CheckHealth(ctx, tu.Spec.HealthChecks)
+	if emit {
+		if checkErr != nil {
+			r.Recorder.Event(tu, corev1.EventTypeWarning, "HealthChecksFailed", checkErr.Error())
+		} else {
+			r.Recorder.Eventf(tu, corev1.EventTypeNormal, "HealthChecksPassed",
+				"All %d health check(s) passed", len(tu.Spec.HealthChecks))
+		}
+	}
+	return checkErr
 }
 
 func (r *Reconciler) emitPhaseEvent(tu *tupprv1alpha1.TalosUpgrade, prev, next tupprv1alpha1.JobPhase, message string) {

--- a/internal/controller/talosupgrade/audit_test.go
+++ b/internal/controller/talosupgrade/audit_test.go
@@ -2,6 +2,7 @@ package talosupgrade
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -318,4 +319,68 @@ func TestSyncLocalAuditFields_Talos(t *testing.T) {
 			t.Fatal("want CompletedAt cleared")
 		}
 	})
+}
+
+func TestRunHealthChecks_Talos_EmitsEvents(t *testing.T) {
+	check := tupprv1alpha1.HealthCheckSpec{APIVersion: "v1", Kind: "Node", Expr: "status != null"}
+	tests := []struct {
+		name       string
+		checks     []tupprv1alpha1.HealthCheckSpec
+		checkErr   error
+		wantEvents []string
+	}{
+		{
+			name:       "pass emits started and passed",
+			checks:     []tupprv1alpha1.HealthCheckSpec{check},
+			wantEvents: []string{"HealthChecksStarted", "HealthChecksPassed"},
+		},
+		{
+			name:       "failure emits started and warning",
+			checks:     []tupprv1alpha1.HealthCheckSpec{check},
+			checkErr:   errors.New("nodes not ready"),
+			wantEvents: []string{"HealthChecksStarted", "HealthChecksFailed"},
+		},
+		{
+			name: "no configured checks emits nothing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tu := newTalosUpgrade("test", func(tu *tupprv1alpha1.TalosUpgrade) {
+				tu.Spec.HealthChecks = tt.checks
+			})
+			recorder := record.NewFakeRecorder(4)
+			r := &Reconciler{Recorder: recorder, HealthChecker: &mockHealthChecker{err: tt.checkErr}}
+
+			if err := r.runHealthChecks(context.Background(), tu); !errors.Is(err, tt.checkErr) {
+				t.Fatalf("want checker error %v, got %v", tt.checkErr, err)
+			}
+
+			for _, want := range tt.wantEvents {
+				select {
+				case ev := <-recorder.Events:
+					if !strings.Contains(ev, want) {
+						t.Fatalf("want %s event, got %q", want, ev)
+					}
+				default:
+					t.Fatalf("missing %s event", want)
+				}
+			}
+			select {
+			case ev := <-recorder.Events:
+				t.Fatalf("unexpected extra event %q", ev)
+			default:
+			}
+		})
+	}
+}
+
+func TestRunHealthChecks_Talos_NoRecorderIsSafe(t *testing.T) {
+	tu := newTalosUpgrade("test", func(tu *tupprv1alpha1.TalosUpgrade) {
+		tu.Spec.HealthChecks = []tupprv1alpha1.HealthCheckSpec{{APIVersion: "v1", Kind: "Node", Expr: "status != null"}}
+	})
+	r := &Reconciler{HealthChecker: &mockHealthChecker{}}
+	if err := r.runHealthChecks(context.Background(), tu); err != nil {
+		t.Fatalf("runHealthChecks without recorder must not fail: %v", err)
+	}
 }

--- a/internal/controller/talosupgrade/upgrade.go
+++ b/internal/controller/talosupgrade/upgrade.go
@@ -347,7 +347,7 @@ func (r *Reconciler) processNextBatch(ctx context.Context, talosUpgrade *tupprv1
 		len(talosUpgrade.Status.CompletedNodes) > 0
 
 	if !skipHealthCheck {
-		checkErr := r.HealthChecker.CheckHealth(ctx, talosUpgrade.Spec.HealthChecks)
+		checkErr := r.runHealthChecks(ctx, talosUpgrade)
 		message := "Running health checks"
 		if checkErr != nil {
 			message = fmt.Sprintf("Waiting for health checks: %s", checkErr.Error())


### PR DESCRIPTION
Closes #479

Health check status was only visible in CR status and the Grafana dashboard. While `CheckHealth` blocks polling (up to its timeout), nothing was observable via `kubectl describe` / `kubectl get events`.

Both reconcilers now route health checks through a `runHealthChecks` wrapper that emits Events on the upgrade CR:

- `HealthChecksStarted` (Normal) before each check attempt - the phase is only written after `CheckHealth` returns, so this is the only signal that a possibly minutes-long attempt is in progress
- `HealthChecksPassed` (Normal) when the attempt succeeds
- `HealthChecksFailed` (Warning) with the checker error when it fails or times out

No events are emitted when `spec.healthChecks` is empty (`CheckHealth` is a no-op there) or when inter-batch checks are suppressed by pre-hooks. Event volume is naturally bounded by the blocking poll loop (one attempt per ~11 minutes while unhealthy), and identical repeats are aggregated by the recorder.

Includes unit tests for both controllers and a docs note in the health checks section.