### PR TITLE
fix(metrics): keep alert-backing metric series alive across restarts

### DIFF
--- a/internal/controller/kubernetesupgrade/controller.go
+++ b/internal/controller/kubernetesupgrade/controller.go
@@ -287,6 +287,12 @@ func (r *Reconciler) syncMetricsFromStatus(kubernetesUpgrade *tupprv1alpha1.Kube
 
 	r.MetricsReporter.RecordKubernetesUpgradePhase(kubernetesUpgrade.Name, string(phase))
 
+	// Re-emit Progressing so a blocked upgrade keeps its series across operator
+	// restarts; setPhaseWithUpdates skips it when the status hasn't changed.
+	if prog := meta.FindStatusCondition(kubernetesUpgrade.Status.Conditions, tupprv1alpha1.ConditionTypeProgressing); prog != nil {
+		r.MetricsReporter.RecordProgressing(metrics.UpgradeTypeKubernetes, kubernetesUpgrade.Name, prog.Reason, prog.Status == metav1.ConditionTrue)
+	}
+
 	if phase.IsTerminal() && kubernetesUpgrade.Status.CompletedAt != nil {
 		r.MetricsReporter.RecordLastCompletionTimestamp(
 			metrics.UpgradeTypeKubernetes,

--- a/internal/controller/kubernetesupgrade/controller_test.go
+++ b/internal/controller/kubernetesupgrade/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	tupprv1alpha1 "github.com/home-operations/tuppr/api/v1alpha1"
@@ -1347,5 +1348,53 @@ func TestK8sReconcile_ReportsReconcileErrorInStatus(t *testing.T) {
 				t.Fatalf("expected message to include the underlying error, got: %s", updated.Status.Message)
 			}
 		})
+	}
+}
+
+func gatherProgressingSeries(t *testing.T, upgradeType, name string) (string, float64, bool) {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "tuppr_upgrade_progressing" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["upgrade_type"] == upgradeType && labels["name"] == name {
+				return labels["reason"], m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+func TestSyncMetricsFromStatusReemitsProgressing(t *testing.T) {
+	r := &Reconciler{MetricsReporter: metrics.NewReporter()}
+	ku := &tupprv1alpha1.KubernetesUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "reseed-kubernetes"},
+		Status: tupprv1alpha1.KubernetesUpgradeStatus{
+			Phase: tupprv1alpha1.JobPhasePending,
+			Conditions: []metav1.Condition{{
+				Type:   tupprv1alpha1.ConditionTypeProgressing,
+				Status: metav1.ConditionFalse,
+				Reason: upgradeaudit.ReasonSuspended,
+			}},
+		},
+	}
+
+	r.syncMetricsFromStatus(ku)
+
+	reason, value, found := gatherProgressingSeries(t, metrics.UpgradeTypeKubernetes, "reseed-kubernetes")
+	if !found {
+		t.Fatal("expected tuppr_upgrade_progressing series after syncMetricsFromStatus")
+	}
+	if reason != upgradeaudit.ReasonSuspended || value != 0 {
+		t.Fatalf("progressing = {reason: %s, value: %v}, want {%s, 0}", reason, value, upgradeaudit.ReasonSuspended)
 	}
 }

--- a/internal/controller/talosupgrade/controller.go
+++ b/internal/controller/talosupgrade/controller.go
@@ -356,6 +356,12 @@ func (r *Reconciler) syncMetricsFromStatus(talosUpgrade *tupprv1alpha1.TalosUpgr
 	}
 	r.MetricsReporter.RecordTalosUpgradePhase(talosUpgrade.Name, string(phase), currentNode)
 
+	// Re-emit Progressing so a blocked upgrade keeps its series across operator
+	// restarts; setPhaseWithUpdates skips it when the status hasn't changed.
+	if prog := meta.FindStatusCondition(talosUpgrade.Status.Conditions, tupprv1alpha1.ConditionTypeProgressing); prog != nil {
+		r.MetricsReporter.RecordProgressing(metrics.UpgradeTypeTalos, talosUpgrade.Name, prog.Reason, prog.Status == metav1.ConditionTrue)
+	}
+
 	if phase.IsTerminal() {
 		completed := len(talosUpgrade.Status.CompletedNodes)
 		failed := len(talosUpgrade.Status.FailedNodes)

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -4642,5 +4643,53 @@ func TestTalosReconcile_StaleRebootTrackingCleared(t *testing.T) {
 	}
 	if updated.Status.Phase != tupprv1alpha1.JobPhaseCompleted {
 		t.Fatalf("expected phase Completed, got: %s", updated.Status.Phase)
+	}
+}
+
+func gatherProgressingSeries(t *testing.T, upgradeType, name string) (string, float64, bool) {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != "tuppr_upgrade_progressing" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["upgrade_type"] == upgradeType && labels["name"] == name {
+				return labels["reason"], m.GetGauge().GetValue(), true
+			}
+		}
+	}
+	return "", 0, false
+}
+
+func TestSyncMetricsFromStatusReemitsProgressing(t *testing.T) {
+	r := &Reconciler{MetricsReporter: metrics.NewReporter()}
+	tu := &tupprv1alpha1.TalosUpgrade{
+		ObjectMeta: metav1.ObjectMeta{Name: "reseed-talos"},
+		Status: tupprv1alpha1.TalosUpgradeStatus{
+			Phase: tupprv1alpha1.JobPhasePending,
+			Conditions: []metav1.Condition{{
+				Type:   tupprv1alpha1.ConditionTypeProgressing,
+				Status: metav1.ConditionFalse,
+				Reason: upgradeaudit.ReasonWaitingForImage,
+			}},
+		},
+	}
+
+	r.syncMetricsFromStatus(tu)
+
+	reason, value, found := gatherProgressingSeries(t, metrics.UpgradeTypeTalos, "reseed-talos")
+	if !found {
+		t.Fatal("expected tuppr_upgrade_progressing series after syncMetricsFromStatus")
+	}
+	if reason != upgradeaudit.ReasonWaitingForImage || value != 0 {
+		t.Fatalf("progressing = {reason: %s, value: %v}, want {%s, 0}", reason, value, upgradeaudit.ReasonWaitingForImage)
 	}
 }

--- a/internal/metrics/reporter.go
+++ b/internal/metrics/reporter.go
@@ -518,6 +518,14 @@ func (m *Reporter) RecordBuildInfo(version, commit, goVersion string) {
 func (m *Reporter) InitializeAtBoot() {
 	upgradeJobsActive.WithLabelValues(UpgradeTypeTalos).Set(0)
 	upgradeJobsActive.WithLabelValues(UpgradeTypeKubernetes).Set(0)
+	// Counters must exist at zero before their first Inc, otherwise PromQL
+	// increase()/rate() miss the initial increment and absent-family alert
+	// expressions never match.
+	for _, upgradeType := range []string{UpgradeTypeTalos, UpgradeTypeKubernetes} {
+		for _, result := range []string{ResultSuccess, ResultFailure} {
+			upgradesCompletedTotal.WithLabelValues(upgradeType, result).Add(0)
+		}
+	}
 	for _, p := range talosPhases {
 		upgradesByPhase.WithLabelValues(UpgradeTypeTalos, p).Set(0)
 	}

--- a/internal/metrics/reporter_test.go
+++ b/internal/metrics/reporter_test.go
@@ -239,6 +239,24 @@ func TestRecordMaintenanceWindows(t *testing.T) {
 	mr.RecordMaintenanceWindows(nil)
 }
 
+func TestInitializeAtBootSeedsCompletionCounter(t *testing.T) {
+	upgradesCompletedTotal.Reset()
+	mr := NewReporter()
+
+	mr.InitializeAtBoot()
+
+	if got := testutil.CollectAndCount(upgradesCompletedTotal); got != 4 {
+		t.Errorf("upgrades_completed_total series after boot = %d, want 4", got)
+	}
+	for _, upgradeType := range []string{UpgradeTypeTalos, UpgradeTypeKubernetes} {
+		for _, result := range []string{ResultSuccess, ResultFailure} {
+			if got := testutil.ToFloat64(upgradesCompletedTotal.WithLabelValues(upgradeType, result)); got != 0 {
+				t.Errorf("upgrades_completed_total{%s,%s} = %v, want 0", upgradeType, result, got)
+			}
+		}
+	}
+}
+
 func TestRecordProgressing(t *testing.T) {
 	mr := NewReporter()
 


### PR DESCRIPTION
## Summary

The `TupprUpgradeBlocked` and `TupprUpgradeFailureRate` alerts key off `tuppr_upgrade_progressing` and `tuppr_upgrades_completed_total`. Both metrics exist and are wired into the controllers, but as label vectors they export no series until a child is instantiated, and neither survives an operator restart:

- `tuppr_upgrades_completed_total` is only incremented on a live transition to a terminal phase, so the family is absent until the first completion after pod start, and `increase()` misses the initial increment of a newly appearing series.
- `tuppr_upgrade_progressing` is only emitted from `setPhaseWithUpdates`, which early-returns when the status hasn't changed. After a restart, a persistently blocked upgrade (Pending with `Waiting*`/`Suspended`) never re-emits its series, so `TupprUpgradeBlocked` can never fire for exactly the long-blocked case it targets.

This is why both families were observed absent in-cluster in #486 - the alert expressions themselves are correct.

## Changes

- Seed `tuppr_upgrades_completed_total` at zero for all `(upgrade_type, result)` pairs in `InitializeAtBoot`.
- Re-emit the Progressing gauge from the CR's stored `Progressing` condition in `syncMetricsFromStatus` in both controllers, which runs on every reconcile.

## Testing

- `mise run test` (unit tests incl. new regression tests for the boot seeding and the restart re-seed path)
- `mise run lint`, `mise run vet`

Fixes #486