### PR TITLE
fix(controller): judge Job outcome by the JobFailed condition, not Failed vs backoffLimit

### DIFF
--- a/internal/controller/jobs/jobs.go
+++ b/internal/controller/jobs/jobs.go
@@ -214,12 +214,26 @@ func DeleteJob(ctx context.Context, c client.Client, job *batchv1.Job) error {
 	})
 }
 
-func IsTerminal(job *batchv1.Job) bool {
-	if job.Status.Succeeded > 0 {
-		return true
-	}
-	if job.Spec.BackoffLimit != nil && job.Status.Failed >= *job.Spec.BackoffLimit {
-		return true
+// IsSucceeded returns true once at least one pod of the Job has succeeded.
+func IsSucceeded(job *batchv1.Job) bool {
+	return job.Status.Succeeded > 0
+}
+
+// IsFailed returns true once the Job controller has marked the Job Failed
+// (backoffLimit exhausted, activeDeadlineSeconds hit, or podFailurePolicy).
+// Comparing Status.Failed against BackoffLimit locally is wrong: backoffLimit=0
+// satisfies Failed >= limit before the pod has run, and Kubernetes only fails a
+// Job when Failed exceeds (not reaches) the limit.
+func IsFailed(job *batchv1.Job) bool {
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return true
+		}
 	}
 	return false
+}
+
+// IsTerminal returns true when the Job has finished, successfully or not.
+func IsTerminal(job *batchv1.Job) bool {
+	return IsSucceeded(job) || IsFailed(job)
 }

--- a/internal/controller/jobs/jobs_test.go
+++ b/internal/controller/jobs/jobs_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/home-operations/tuppr/internal/constants"
@@ -268,6 +269,84 @@ func TestDeleteJob(t *testing.T) {
 			remaining, err := ListJobsByLabel(context.Background(), cl, "default", "talos-upgrade")
 			if err != nil || len(remaining) != tt.wantCount {
 				t.Fatalf("got (%v, %v), want %d remaining", remaining, err, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	tests := []struct {
+		name         string
+		job          *batchv1.Job
+		wantTerminal bool
+		wantFailed   bool
+	}{
+		{
+			// Regression for #522: backoffLimit=0 made Failed >= limit true at creation.
+			name: "fresh job with backoffLimit=0 is not terminal",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{BackoffLimit: ptr.To(int32(0))},
+			},
+		},
+		{
+			name: "pod failure without JobFailed condition is not terminal",
+			job: &batchv1.Job{
+				Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(0))},
+				Status: batchv1.JobStatus{Failed: 1},
+			},
+		},
+		{
+			// The old Failed >= limit check gave up one attempt early.
+			name: "failed count at backoffLimit without condition is still retrying",
+			job: &batchv1.Job{
+				Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2))},
+				Status: batchv1.JobStatus{Failed: 2, Active: 1},
+			},
+		},
+		{
+			name: "succeeded pod is terminal",
+			job: &batchv1.Job{
+				Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(0))},
+				Status: batchv1.JobStatus{Succeeded: 1},
+			},
+			wantTerminal: true,
+		},
+		{
+			name: "JobFailed condition is terminal and failed",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{BackoffLimit: ptr.To(int32(0))},
+				Status: batchv1.JobStatus{
+					Failed: 1,
+					Conditions: []batchv1.JobCondition{{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			wantTerminal: true,
+			wantFailed:   true,
+		},
+		{
+			name: "false JobFailed condition is not terminal",
+			job: &batchv1.Job{
+				Spec: batchv1.JobSpec{BackoffLimit: ptr.To(int32(0))},
+				Status: batchv1.JobStatus{
+					Conditions: []batchv1.JobCondition{{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionFalse,
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerminal(tt.job); got != tt.wantTerminal {
+				t.Fatalf("IsTerminal() = %v, want %v", got, tt.wantTerminal)
+			}
+			if got := IsFailed(tt.job); got != tt.wantFailed {
+				t.Fatalf("IsFailed() = %v, want %v", got, tt.wantFailed)
 			}
 		})
 	}

--- a/internal/controller/kubernetesupgrade/controller_test.go
+++ b/internal/controller/kubernetesupgrade/controller_test.go
@@ -579,8 +579,14 @@ func TestK8sReconcile_HandlesJobFailure(t *testing.T) {
 				targetNodeLabelKey: fakeCrtl,
 			},
 		},
-		Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
-		Status: batchv1.JobStatus{Failed: 2},
+		Spec: batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
+		Status: batchv1.JobStatus{
+			Failed: 2,
+			Conditions: []batchv1.JobCondition{{
+				Type:   batchv1.JobFailed,
+				Status: corev1.ConditionTrue,
+			}},
+		},
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(ku, job).WithStatusSubresource(ku).Build()

--- a/internal/controller/kubernetesupgrade/jobs.go
+++ b/internal/controller/kubernetesupgrade/jobs.go
@@ -35,7 +35,7 @@ func (r *Reconciler) handleJobStatus(ctx context.Context, kubernetesUpgrade *tup
 		"failed", job.Status.Failed,
 		"backoffLimit", *job.Spec.BackoffLimit)
 
-	if job.Status.Succeeded == 0 && (job.Status.Failed == 0 || job.Status.Failed < *job.Spec.BackoffLimit) {
+	if !jobs.IsTerminal(job) {
 		message := fmt.Sprintf("Upgrading Kubernetes to %s (job: %s)", kubernetesUpgrade.Spec.Kubernetes.Version, job.Name)
 		if err := r.setPhaseWithUpdates(ctx, kubernetesUpgrade, tupprv1alpha1.JobPhaseUpgrading, "", kubernetesUpgrade.Status.ControllerNode, message, map[string]any{
 			statusFieldJobName: job.Name,
@@ -47,7 +47,7 @@ func (r *Reconciler) handleJobStatus(ctx context.Context, kubernetesUpgrade *tup
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	if job.Status.Succeeded > 0 {
+	if jobs.IsSucceeded(job) {
 		return r.handleJobSuccess(ctx, kubernetesUpgrade, job)
 	}
 

--- a/internal/controller/talosupgrade/controller_test.go
+++ b/internal/controller/talosupgrade/controller_test.go
@@ -184,6 +184,17 @@ func newTestScheme() *runtime.Scheme {
 	return s
 }
 
+// failedJobStatus mimics the job controller declaring the Job Failed.
+func failedJobStatus(failed int32) batchv1.JobStatus {
+	return batchv1.JobStatus{
+		Failed: failed,
+		Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobFailed,
+			Status: corev1.ConditionTrue,
+		}},
+	}
+}
+
 func newTalosUpgrade(name string, opts ...func(*tupprv1alpha1.TalosUpgrade)) *tupprv1alpha1.TalosUpgrade {
 	tu := &tupprv1alpha1.TalosUpgrade{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1003,7 +1014,7 @@ func TestTalosReconcile_HandlesJobFailure(t *testing.T) {
 			},
 		},
 		Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
-		Status: batchv1.JobStatus{Failed: 2},
+		Status: failedJobStatus(2),
 	}
 	cl := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(tu, job).WithStatusSubresource(tu).Build()
@@ -1553,7 +1564,7 @@ func TestTalosReconcile_FailedJobButNodeUpgraded_TreatedAsSuccess(t *testing.T) 
 			},
 		},
 		Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
-		Status: batchv1.JobStatus{Failed: 2}, // pod evicted by the reboot, backoff exhausted
+		Status: failedJobStatus(2), // pod evicted by the reboot, backoff exhausted
 	}
 	tc := &mockTalosClient{
 		nodeVersions:  map[string]string{testNodeIP1: fakeTalosVersion}, // node DID reach target
@@ -1608,7 +1619,7 @@ func TestTalosReconcile_FailedJobButNodeRebooting_TreatedAsRebooting(t *testing.
 			},
 		},
 		Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
-		Status: batchv1.JobStatus{Failed: 2},
+		Status: failedJobStatus(2),
 	}
 	// Node is still rebooting: the Talos API is not reachable yet (transient error).
 	tc := &mockTalosClient{
@@ -1652,7 +1663,7 @@ func TestTalosReconcile_FailedOffTargetJobWithOldVersion_FailsImmediately(t *tes
 			},
 		},
 		Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
-		Status: batchv1.JobStatus{Failed: 2},
+		Status: failedJobStatus(2),
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3900,7 +3911,7 @@ func TestTalosReconcile_BatchOneJobFails(t *testing.T) {
 			jobList.Items[i].Status.Succeeded = 1
 			tc.nodeVersions[testNodeIP1] = fakeTalosVersion
 		} else {
-			jobList.Items[i].Status.Failed = *jobList.Items[i].Spec.BackoffLimit
+			jobList.Items[i].Status = failedJobStatus(*jobList.Items[i].Spec.BackoffLimit + 1)
 		}
 		if err := cl.Status().Update(context.Background(), &jobList.Items[i]); err != nil {
 			t.Fatalf("failed to update job status: %v", err)
@@ -4488,7 +4499,7 @@ func TestTalosReconcile_RebootingNodeTimesOut_JobStillPresent(t *testing.T) {
 			},
 		},
 		Spec:   batchv1.JobSpec{BackoffLimit: ptr.To(int32(2)), Template: corev1.PodTemplateSpec{}},
-		Status: batchv1.JobStatus{Failed: 2},
+		Status: failedJobStatus(2),
 	}
 	tc := &mockTalosClient{
 		checkReadyErr: fmt.Errorf("connection refused"),

--- a/internal/controller/talosupgrade/hooks.go
+++ b/internal/controller/talosupgrade/hooks.go
@@ -135,7 +135,7 @@ func (r *Reconciler) handleHookJobStatus(ctx context.Context, tu *tupprv1alpha1.
 	idx := hookIndex(tu, phase)
 	hookName := job.Labels[hookNameLabel]
 
-	if job.Status.Succeeded > 0 {
+	if jobs.IsSucceeded(job) {
 		logger.Info("Hook job succeeded", "phase", phase, "hook", hookName, "index", idx, "job", job.Name)
 		r.MetricsReporter.RecordHookExecution(tu.Name, phase, hookName, "success")
 		if err := r.advanceHookIndex(ctx, tu, phase, idx+1); err != nil {

--- a/internal/controller/talosupgrade/hooks_test.go
+++ b/internal/controller/talosupgrade/hooks_test.go
@@ -58,6 +58,7 @@ func markJobSucceeded(t *testing.T, cl client.Client, job batchv1.Job) {
 	}
 }
 
+// markJobFailed mimics the job controller declaring the Job Failed.
 func markJobFailed(t *testing.T, cl client.Client, job batchv1.Job) {
 	t.Helper()
 	if job.Spec.BackoffLimit != nil {
@@ -65,6 +66,10 @@ func markJobFailed(t *testing.T, cl client.Client, job batchv1.Job) {
 	} else {
 		job.Status.Failed = 1
 	}
+	job.Status.Conditions = append(job.Status.Conditions, batchv1.JobCondition{
+		Type:   batchv1.JobFailed,
+		Status: corev1.ConditionTrue,
+	})
 	if err := cl.Status().Update(context.Background(), &job); err != nil {
 		t.Fatalf("mark job failed: %v", err)
 	}
@@ -158,6 +163,53 @@ func TestProcessHookPhase_CreatesJobThenAdvancesOnSuccess(t *testing.T) {
 	}
 	if updated.Status.PreHookFailed {
 		t.Fatal("expected PreHookFailed=false on success path")
+	}
+}
+
+// Regression for #522: a hook with the default backoffLimit=0 must not be
+// judged by Failed >= limit (true at creation); it stays pending until the
+// job controller reports an outcome.
+func TestProcessHookPhase_FreshJobWithZeroBackoffIsNotFailed(t *testing.T) {
+	scheme := newTestScheme()
+
+	tu := newTalosUpgrade("tu",
+		withFinalizer,
+		withPhase(tupprv1alpha1.JobPhasePreHook),
+		withHooks([]tupprv1alpha1.HookSpec{cephNoutHook("set-noout", "set")}, nil),
+	)
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(tu).WithStatusSubresource(tu).Build()
+	r := newTalosReconciler(cl, scheme, &mockTalosClient{}, &mockHealthChecker{})
+
+	// First reconcile creates the hook Job with backoffLimit=0 and an empty status.
+	reconcileTalos(t, r, "tu")
+	jobs := listHookJobs(t, cl, hookPhasePre)
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 pre-hook job, got %d", len(jobs))
+	}
+	if jobs[0].Spec.BackoffLimit == nil || *jobs[0].Spec.BackoffLimit != 0 {
+		t.Fatalf("expected default backoffLimit=0, got %v", jobs[0].Spec.BackoffLimit)
+	}
+
+	// Poll again before the pod has run: the hook must still be in flight.
+	reconcileTalos(t, r, "tu")
+
+	updated := getTalosUpgrade(t, cl, "tu")
+	if updated.Status.PreHookFailed {
+		t.Fatal("expected PreHookFailed=false while the job has no outcome")
+	}
+	if updated.Status.PreHookIndex != 0 {
+		t.Fatalf("expected PreHookIndex=0 while the job has no outcome, got %d", updated.Status.PreHookIndex)
+	}
+	if jobs := listHookJobs(t, cl, hookPhasePre); len(jobs) != 1 {
+		t.Fatalf("expected the pending hook job to survive the poll, got %d jobs", len(jobs))
+	}
+
+	// A real pod failure (job controller sets JobFailed) still fails the hook.
+	markJobFailed(t, cl, jobs[0])
+	reconcileTalos(t, r, "tu")
+	if updated := getTalosUpgrade(t, cl, "tu"); !updated.Status.PreHookFailed {
+		t.Fatal("expected PreHookFailed=true after the job controller marks it Failed")
 	}
 }
 

--- a/internal/controller/talosupgrade/jobs.go
+++ b/internal/controller/talosupgrade/jobs.go
@@ -93,10 +93,10 @@ func (r *Reconciler) handleBatchJobStatus(ctx context.Context, talosUpgrade *tup
 		// Succeeded and exhausted-backoff Jobs are both terminal; the node's real
 		// state (verified below) decides the outcome, not the Job's exit status.
 		switch {
-		case job.Status.Succeeded > 0:
+		case jobs.IsSucceeded(&job):
 			succeededCount++
 			terminalJobs = append(terminalJobs, job)
-		case job.Status.Failed >= *job.Spec.BackoffLimit:
+		case jobs.IsFailed(&job):
 			failedCount++
 			terminalJobs = append(terminalJobs, job)
 		default:
@@ -144,7 +144,7 @@ func (r *Reconciler) handleBatchJobStatus(ctx context.Context, talosUpgrade *tup
 	for i := range terminalJobs {
 		job := &terminalJobs[i]
 		nodeName := job.Labels[targetNodeLabelKey]
-		jobFailed := job.Status.Failed >= *job.Spec.BackoffLimit
+		jobFailed := jobs.IsFailed(job)
 
 		result, failureMessage, err := r.processTerminalJob(ctx, talosUpgrade, job, nodeName, jobFailed)
 		if err != nil {


### PR DESCRIPTION
Fixes #522.

## Problem

`jobs.IsTerminal` derived terminality from `Status.Failed >= *Spec.BackoffLimit`. Hook Jobs default to `backoffLimit: 0`, so `0 >= 0` was true from the moment the Job object existed — any hook without an explicit `backoffLimit` was racing pod scheduling + image pull against the controller's 10s poll, and on a slow node was marked failed before its pod ever started. For a pre-hook that aborts the entire upgrade run.

The comparison was also off by one for every limit: Kubernetes fails a Job when `Failed` *exceeds* `backoffLimit` (`exceedsBackoffLimit := jobCtx.failed > *job.Spec.BackoffLimit`, strictly greater), i.e. it runs `backoffLimit + 1` attempts. With `>=`, tuppr declared failure one attempt early — the talos upgrade path even computes its timeout as `TalosJobBackoffLimit + 1` attempts while the old check gave up after `TalosJobBackoffLimit` failures, potentially deleting a Job whose final retry was still running.

## Fix

Stop re-deriving terminality and defer to the job controller's verdict:

- `IsFailed` returns true only once the Job carries a `JobFailed` condition with status `True`. This is authoritative for `backoffLimit`, `activeDeadlineSeconds`, and `podFailurePolicy` alike.
- `IsSucceeded` stays `Status.Succeeded > 0` — it cannot be true before a pod has actually succeeded, so it keeps the fast success path with no race.
- `IsTerminal` is the disjunction of the two.

The kubernetesupgrade controller's inline copy of the same `Failed`-count check is replaced with the shared helpers.

Note the issue's first suggested fix (skip the check when `backoffLimit == 0`) would have traded the false failure for a hang: a default-limit hook whose pod genuinely fails would never become terminal, since nothing inspected Job conditions.

## Behavior notes

- `backoffLimit: 0` keeps its documented "fail fast, no retries" meaning — the hook now fails after the first *actual* pod failure instead of before the first pod runs.
- Jobs now get their full `backoffLimit + 1` attempts before tuppr declares failure, matching upstream semantics.
- Marking failure can lag slightly behind the last pod failure (the job controller sets `JobFailed` only after all pods terminate), which is the correct, non-racy ordering.

## Testing

- New `TestIsTerminal` table in `internal/controller/jobs` covering the #522 regression (fresh `backoffLimit=0` Job is not terminal), an in-flight retry at the limit, and both condition polarities.
- New `TestProcessHookPhase_FreshJobWithZeroBackoffIsNotFailed` reproducing the reported scenario end-to-end: the created hook Job survives polls with an empty status, and still fails once the job controller marks it `Failed`.
- Failure-simulating test fixtures now set the `JobFailed` condition, as the real job controller does.
- `mise run vet`, `mise run lint`, `mise run test`, and `mise run test-integration` all pass.