### PR TITLE
chore(crd): regenerate manifests for k8s.io/api v0.37.0

### DIFF
--- a/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
+++ b/config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml
@@ -236,7 +236,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -442,10 +444,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -720,6 +733,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   items:
                                     description: |-
                                       items if unspecified, each key-value pair in the Data field of the referenced
@@ -753,6 +773,13 @@ spec:
                                             May not contain the path element '..'.
                                             May not start with the string '..'.
                                           type: string
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - key
                                       - path
@@ -840,6 +867,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   items:
                                     description: Items is a list of downward API volume
                                       file
@@ -910,6 +944,13 @@ spec:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - path
                                       type: object
@@ -928,6 +969,18 @@ spec:
                                       Must be an empty string (default) or Memory.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
+                                  mode:
+                                    description: |-
+                                      mode specifies the permission bits for the emptyDir directory, in numeric
+                                      notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                                      If not specified, defaults to 0777.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                                      will override the mode specified here.
+                                      This field has no effect on Windows.
+                                      This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                                    format: int32
+                                    type: integer
                                   sizeLimit:
                                     anyOf:
                                     - type: integer
@@ -1021,8 +1074,8 @@ spec:
                                               * An existing PVC (PersistentVolumeClaim)
                                               If the provisioner or an external controller can support the specified data source,
                                               it will create a new volume based on the contents of the specified data source.
-                                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                              dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                              copied to dataSource when dataSourceRef.namespace is not specified.
                                               If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                             properties:
                                               apiGroup:
@@ -1067,7 +1120,6 @@ spec:
                                                 specified.
                                               * While dataSource only allows local objects, dataSourceRef allows objects
                                                 in any namespaces.
-                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                               (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                             properties:
                                               apiGroup:
@@ -1638,6 +1690,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   sources:
                                     description: |-
                                       sources is the list of volume projections. Each entry in this list
@@ -1738,6 +1797,13 @@ spec:
                                                 Mutually-exclusive with name.  The contents of all selected
                                                 ClusterTrustBundles will be unified and deduplicated.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
@@ -1779,6 +1845,13 @@ spec:
                                                       May not contain the path element '..'.
                                                       May not start with the string '..'.
                                                     type: string
+                                                  user:
+                                                    description: |-
+                                                      user is Optional: The owner UID of the created file.
+                                                      If specified, the item-level user field takes precedence over defaultUser.
+                                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                                    format: int64
+                                                    type: integer
                                                 required:
                                                 - key
                                                 - path
@@ -1880,6 +1953,13 @@ spec:
                                                     - resource
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  user:
+                                                    description: |-
+                                                      user is Optional: The owner UID of the created file.
+                                                      If specified, the item-level user field takes precedence over defaultUser.
+                                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                                    format: int64
+                                                    type: integer
                                                 required:
                                                 - path
                                                 type: object
@@ -1987,6 +2067,13 @@ spec:
                                               description: Kubelet's generated CSRs
                                                 will be addressed to this signer.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                             userAnnotations:
                                               additionalProperties:
                                                 type: string
@@ -2047,6 +2134,13 @@ spec:
                                                       May not contain the path element '..'.
                                                       May not start with the string '..'.
                                                     type: string
+                                                  user:
+                                                    description: |-
+                                                      user is Optional: The owner UID of the created file.
+                                                      If specified, the item-level user field takes precedence over defaultUser.
+                                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                                    format: int64
+                                                    type: integer
                                                 required:
                                                 - key
                                                 - path
@@ -2096,6 +2190,13 @@ spec:
                                                 path is the path relative to the mount point of the file to project the
                                                 token into.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
@@ -2303,6 +2404,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   items:
                                     description: |-
                                       items If unspecified, each key-value pair in the Data field of the referenced
@@ -2336,6 +2444,13 @@ spec:
                                             May not contain the path element '..'.
                                             May not start with the string '..'.
                                           type: string
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - key
                                       - path
@@ -2496,7 +2611,9 @@ spec:
                                     description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
+                                        description: |-
+                                          The key to select from the ConfigMap's Data field.
+                                          Keys in the BinaryData field are not currently propagated to container env vars.
                                         type: string
                                       name:
                                         default: ""
@@ -2702,10 +2819,21 @@ spec:
                             description: VolumeMount describes a mounting of a Volume
                               within a container.
                             properties:
-                              mountPath:
+                              bindMountOptions:
                                 description: |-
-                                  Path within the container at which the volume should be mounted.  Must
-                                  not contain ':'.
+                                  bindMountOptions is the list of additional bind mount options to apply when
+                                  mounting this volume into the container. Allowed values are noexec,
+                                  nodev, and nosuid. These are Linux mount options and have no effect on
+                                  Windows nodes.
+                                  This field is not supported with image volumes.
+                                  This is an alpha field and requires enabling the VolumeBindMountOptions feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.
                                 type: string
                               mountPropagation:
                                 description: |-
@@ -2980,6 +3108,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   items:
                                     description: |-
                                       items if unspecified, each key-value pair in the Data field of the referenced
@@ -3013,6 +3148,13 @@ spec:
                                             May not contain the path element '..'.
                                             May not start with the string '..'.
                                           type: string
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - key
                                       - path
@@ -3100,6 +3242,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   items:
                                     description: Items is a list of downward API volume
                                       file
@@ -3170,6 +3319,13 @@ spec:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - path
                                       type: object
@@ -3188,6 +3344,18 @@ spec:
                                       Must be an empty string (default) or Memory.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
+                                  mode:
+                                    description: |-
+                                      mode specifies the permission bits for the emptyDir directory, in numeric
+                                      notation (e.g., 0755, 01777). Must be a value between 0000 and 01777.
+                                      If not specified, defaults to 0777.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup. If fsGroup is specified, the fsGroup permissions
+                                      will override the mode specified here.
+                                      This field has no effect on Windows.
+                                      This field is alpha and requires EmptyDirVolumeMode featuregate to be enabled.
+                                    format: int32
+                                    type: integer
                                   sizeLimit:
                                     anyOf:
                                     - type: integer
@@ -3281,8 +3449,8 @@ spec:
                                               * An existing PVC (PersistentVolumeClaim)
                                               If the provisioner or an external controller can support the specified data source,
                                               it will create a new volume based on the contents of the specified data source.
-                                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
-                                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                              dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be
+                                              copied to dataSource when dataSourceRef.namespace is not specified.
                                               If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                             properties:
                                               apiGroup:
@@ -3327,7 +3495,6 @@ spec:
                                                 specified.
                                               * While dataSource only allows local objects, dataSourceRef allows objects
                                                 in any namespaces.
-                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                               (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                             properties:
                                               apiGroup:
@@ -3898,6 +4065,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   sources:
                                     description: |-
                                       sources is the list of volume projections. Each entry in this list
@@ -3998,6 +4172,13 @@ spec:
                                                 Mutually-exclusive with name.  The contents of all selected
                                                 ClusterTrustBundles will be unified and deduplicated.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
@@ -4039,6 +4220,13 @@ spec:
                                                       May not contain the path element '..'.
                                                       May not start with the string '..'.
                                                     type: string
+                                                  user:
+                                                    description: |-
+                                                      user is Optional: The owner UID of the created file.
+                                                      If specified, the item-level user field takes precedence over defaultUser.
+                                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                                    format: int64
+                                                    type: integer
                                                 required:
                                                 - key
                                                 - path
@@ -4140,6 +4328,13 @@ spec:
                                                     - resource
                                                     type: object
                                                     x-kubernetes-map-type: atomic
+                                                  user:
+                                                    description: |-
+                                                      user is Optional: The owner UID of the created file.
+                                                      If specified, the item-level user field takes precedence over defaultUser.
+                                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                                    format: int64
+                                                    type: integer
                                                 required:
                                                 - path
                                                 type: object
@@ -4247,6 +4442,13 @@ spec:
                                               description: Kubelet's generated CSRs
                                                 will be addressed to this signer.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                             userAnnotations:
                                               additionalProperties:
                                                 type: string
@@ -4307,6 +4509,13 @@ spec:
                                                       May not contain the path element '..'.
                                                       May not start with the string '..'.
                                                     type: string
+                                                  user:
+                                                    description: |-
+                                                      user is Optional: The owner UID of the created file.
+                                                      If specified, the item-level user field takes precedence over defaultUser.
+                                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                                    format: int64
+                                                    type: integer
                                                 required:
                                                 - key
                                                 - path
@@ -4356,6 +4565,13 @@ spec:
                                                 path is the path relative to the mount point of the file to project the
                                                 token into.
                                               type: string
+                                            user:
+                                              description: |-
+                                                user is Optional: The owner UID of the created file.
+                                                If specified, the item-level user field takes precedence over defaultUser.
+                                                (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                              format: int64
+                                              type: integer
                                           required:
                                           - path
                                           type: object
@@ -4563,6 +4779,13 @@ spec:
                                       mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
+                                  defaultUser:
+                                    description: |-
+                                      defaultUser is Optional: The owner UID of the created files by default.
+                                      The defaultUser field is only used as a fallback when the item-level user field is unset.
+                                      (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                    format: int64
+                                    type: integer
                                   items:
                                     description: |-
                                       items If unspecified, each key-value pair in the Data field of the referenced
@@ -4596,6 +4819,13 @@ spec:
                                             May not contain the path element '..'.
                                             May not start with the string '..'.
                                           type: string
+                                        user:
+                                          description: |-
+                                            user is Optional: The owner UID of the created file.
+                                            If specified, the item-level user field takes precedence over defaultUser.
+                                            (Alpha) This field requires the AtomicWriteVolumeUserFields feature gate to be enabled.
+                                          format: int64
+                                          type: integer
                                       required:
                                       - key
                                       - path


### PR DESCRIPTION
The kubernetes monorepo bump (#527) landed with the chart's CRD copy (`charts/tuppr/crds/`) regenerated, but `config/crd/bases/tuppr.home-operations.com_talosupgrades.yaml` was left stale. Since `mise run vet` depends on `generate`, every local run dirtied the working tree with this ~258-line diff.

This is the verbatim `mise run manifests` output against the current `k8s.io/api` v0.37.0: updated upstream field descriptions plus the new alpha `bindMountOptions` VolumeMount field. No hand edits. `config/crd/bases` and `charts/tuppr/crds` are now byte-identical again.

Worth considering separately: a `generate-check` CI gate (like the existing `helm-docs-check`) so generated manifests can't drift from `go.mod` silently again.

Verified with `mise run vet`, `mise run test`, and `mise run helm-lint`.