### PR TITLE
ci(e2e): drop the legacy action leg now that Talos 1.14 is released

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
       ${{ github.event_name != 'push'
       && !(startsWith(github.head_ref, 'release-please--')
       && github.event.pull_request.head.repo.full_name == github.repository) }}
-    name: Go E2E (${{ matrix.name || format('{0} {1}', matrix.upgrade, matrix.leg) }})
+    name: Go E2E (${{ matrix.upgrade }} ${{ matrix.leg }})
     needs: e2e-image
     runs-on: ubuntu-24.04
     permissions:
@@ -131,39 +131,23 @@ jobs:
         # one picks a single control plane node and runs one job there, so it
         # gets one leg rather than a shape sweep of its own.
         include:
-          # Every Talos leg boots the previous minor (via the previous action
-          # release, since v0.2.x refuses pre-1.14 pins) and upgrades it across
-          # the 1.13 -> 1.14 config-model boundary: the migration every real
-          # cluster performs. Same-minor 1.14 pairs return once two 1.14 tags
-          # exist whose API-access grant works: v1.14.0-beta.0 sits mid-migration
-          # of the kubernetesTalosAPIAccess feature to its 1.14 document, and
-          # neither form conveys roles there, so nothing can authorize the
-          # upgrade pods on a beta.0-booted cluster.
+          # Every Talos leg boots the last 1.14 release candidate and upgrades
+          # it to the release: the same-minor step clusters take repeatedly.
+          # The action's floor is Talos 1.14, so nothing older can boot to
+          # upgrade from.
           #
           # Covers the self-hosted path: with one node tuppr upgrades the node
           # it is running on, so it skips the drain and issues the upgrade
           # without --wait. No other leg reaches that code.
           - leg: 1cp-0w
             upgrade: talos
-            legacy-action: true
           - leg: 1cp-1w
             upgrade: talos
-            legacy-action: true
           - leg: 3cp-0w
             upgrade: talos
-            legacy-action: true
-          # The same-minor pair on the previous line (1.13.5 -> 1.13.7): what
-          # clusters run repeatedly before they ever migrate. Same code path as
-          # the cross-boundary legs on the tuppr side, kept as its own proof.
-          - leg: 1cp-0w
-            name: talos 1.13-same-minor
-            upgrade: talos
-            legacy-action: true
-            talos-upgrade-version: v1.13.7
           # A control plane and a worker, so both kinds of kubelet have to
           # converge on the new version before the CR reports Completed. Boots
-          # current Talos through the current action: no Talos upgrade happens
-          # here, so the beta.0 grant gap does not bite.
+          # the release, since no Talos upgrade happens here.
           - leg: k8s-1cp-1w
             upgrade: kubernetes
     env:
@@ -218,20 +202,8 @@ jobs:
       # itself, because the QEMU provisioner runs under sudo.
       - name: Create cluster
         id: cluster
-        if: ${{ !matrix.legacy-action }}
         background: true
-        uses: home-operations/talosctl-cluster-action@9181b206f3e87c685ef63f53bbf5dc25ed45e85a # v0.2.1
-        with:
-          config: test/e2e-qemu/${{ matrix.leg }}.yaml
-          cache: true
-
-      # The previous release boots the previous Talos minor; a `uses:` ref cannot
-      # come from the matrix, so the legacy leg gets its own step.
-      - name: Create cluster (previous action)
-        id: cluster-legacy
-        if: ${{ matrix.legacy-action }}
-        background: true
-        uses: home-operations/talosctl-cluster-action@42a2d1c476f87245e2d1882ec825fb31368b9686 # v0.1.6
+        uses: home-operations/talosctl-cluster-action@fb6a31bf5de43218acc80d2e23958a16eee7380c # v0.2.2
         with:
           config: test/e2e-qemu/${{ matrix.leg }}.yaml
           cache: true
@@ -249,7 +221,7 @@ jobs:
           docker load -i "${RUNNER_TEMP}/e2e-image.tar.gz"
           docker push "${PUSH_IMAGE}"
 
-      - wait: [cluster, cluster-legacy]
+      - wait: [cluster]
 
       # The action exports KUBECONFIG and TALOSCONFIG too, but naming the outputs
       # keeps it visible which cluster the tests are pointed at, and test.sh
@@ -257,12 +229,10 @@ jobs:
       - name: Run e2e tests
         env:
           UPGRADE_KIND: ${{ matrix.upgrade }}
-          # Empty for most legs, so common.sh's default (the next minor) holds.
-          TALOS_UPGRADE_VERSION: ${{ matrix.talos-upgrade-version || '' }}
-          CLUSTER_NAME: ${{ steps.cluster.outputs.cluster-name || steps.cluster-legacy.outputs.cluster-name }}
-          ENDPOINT: ${{ steps.cluster.outputs.endpoint || steps.cluster-legacy.outputs.endpoint }}
-          KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig || steps.cluster-legacy.outputs.kubeconfig }}
-          TALOSCONFIG: ${{ steps.cluster.outputs.talosconfig || steps.cluster-legacy.outputs.talosconfig }}
+          CLUSTER_NAME: ${{ steps.cluster.outputs.cluster-name }}
+          ENDPOINT: ${{ steps.cluster.outputs.endpoint }}
+          KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig }}
+          TALOSCONFIG: ${{ steps.cluster.outputs.talosconfig }}
         run: mise exec --locked --no-deps -- ./test.sh
 
   go-lint:

--- a/test/e2e-qemu/1cp-0w.yaml
+++ b/test/e2e-qemu/1cp-0w.yaml
@@ -15,7 +15,7 @@ spec:
   workers:
     count: 0
   qemu:
-    talos-version: v1.13.5
+    talos-version: v1.14.0-rc.2
     disks:
       - virtio:10GiB
   config-patches:

--- a/test/e2e-qemu/1cp-1w.yaml
+++ b/test/e2e-qemu/1cp-1w.yaml
@@ -13,7 +13,7 @@ spec:
   workers:
     count: 1
   qemu:
-    talos-version: v1.13.5
+    talos-version: v1.14.0-rc.2
     disks:
       - virtio:10GiB
   config-patches:

--- a/test/e2e-qemu/3cp-0w.yaml
+++ b/test/e2e-qemu/3cp-0w.yaml
@@ -18,7 +18,7 @@ spec:
   workers:
     count: 0
   qemu:
-    talos-version: v1.13.5
+    talos-version: v1.14.0-rc.2
     disks:
       - virtio:10GiB
   config-patches:

--- a/test/e2e-qemu/README.md
+++ b/test/e2e-qemu/README.md
@@ -38,7 +38,7 @@ cr-templates/                           the TalosUpgrade and KubernetesUpgrade u
 
 - KVM (`/dev/kvm`) and `qemu-system-x86_64`
 - Passwordless `sudo`, for the bridge and NAT the provisioner sets up
-- `talosctl` v1.13 or newer, which mise pins
+- `talosctl` v1.14 or newer, which mise pins
 - Docker, to build and push the controller image (skipped if you set
   `CONTROLLER_IMAGE`)
 
@@ -52,7 +52,7 @@ it:
 talosctl cluster create qemu \
     --name tuppr-e2e-1cp-0w \
     --controlplanes 1 --workers 0 \
-    --talos-version v1.13.5 --kubernetes-version 1.34.0 \
+    --talos-version v1.14.0-rc.2 --kubernetes-version 1.34.0 \
     --disks virtio:10GiB \
     --config-patch-controlplanes @patches/talos-api-access.yaml \
     --talosconfig-destination /tmp/tuppr-e2e/talosconfig
@@ -126,9 +126,10 @@ The versions a leg **boots** on are in its document, as `spec.qemu.talos-version
 and `spec.kubernetes-version`. The versions tuppr **upgrades it to** are in
 `common.sh`, as `TALOS_UPGRADE_VERSION` and `K8S_UPGRADE_VERSION`, and both have to
 stay ahead of the documents or the run proves nothing. Talos itself has a floor:
-the action needs `talosctl` v1.13 or newer, so a leg cannot boot anything older
-than v1.13 to upgrade from. Everything else about a shape, including the memory
-ceiling that bounds how many VMs fit on a runner, lives in the document.
+the action targets Talos 1.14 and refuses an older `talosctl` or `talos-version`,
+so a leg cannot boot anything older than v1.14 to upgrade from. Everything else
+about a shape, including the memory ceiling that bounds how many VMs fit on a
+runner, lives in the document.
 
 Keep `metadata.name` short: it appears twice in the QEMU monitor socket path, and
 QEMU refuses to start when a UNIX socket path exceeds 108 bytes. The action checks

--- a/test/e2e-qemu/common.sh
+++ b/test/e2e-qemu/common.sh
@@ -5,7 +5,7 @@
 # What the cluster boots on is declared in the leg documents (<cp>cp-<w>w.yaml);
 # these are what tuppr upgrades it to, and have to stay ahead of them or the run
 # proves nothing.
-TALOS_UPGRADE_VERSION="${TALOS_UPGRADE_VERSION:-v1.14.0-beta.1}"
+TALOS_UPGRADE_VERSION="${TALOS_UPGRADE_VERSION:-v1.14.0}"
 K8S_UPGRADE_VERSION="${K8S_UPGRADE_VERSION:-v1.35.0}"
 
 log() {

--- a/test/e2e-qemu/k8s-1cp-1w.yaml
+++ b/test/e2e-qemu/k8s-1cp-1w.yaml
@@ -1,8 +1,7 @@
 ---
-# The Kubernetes-upgrade leg: boots current Talos through the current action (no
-# Talos upgrade happens here, so the beta.0 grant gap does not apply) and rolls
-# Kubernetes itself. Split from 1cp-1w.yaml because the Talos legs boot the
-# previous minor, which the current action's floor check refuses.
+# The Kubernetes-upgrade leg: rolls Kubernetes itself, so it boots the Talos
+# release rather than the release candidate the Talos legs upgrade from. Split
+# from 1cp-1w.yaml for that version alone.
 # yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/talosctl-cluster-action/main/schema/talos-cluster.json
 # One of each, so a drained workload has somewhere else to land.
 apiVersion: v1alpha1
@@ -17,7 +16,7 @@ spec:
   workers:
     count: 1
   qemu:
-    talos-version: v1.14.0-beta.1
+    talos-version: v1.14.0
     disks:
       - virtio:10GiB
   config-patches:


### PR DESCRIPTION
Every Talos e2e leg used to boot 1.13 through talosctl-cluster-action v0.1.6, since the v0.2 line refuses pre-1.14 pins, and upgrade across the 1.13 to 1.14 boundary. With Talos 1.14.0 out, the legs now boot v1.14.0-rc.2 through the current action (v0.2.2) and upgrade to v1.14.0. The Kubernetes leg boots v1.14.0 directly.

- Remove the legacy-action matrix key, the previous-action cluster step, and the fallback output lookups.
- Remove the 1.13 same-minor leg: with 1.13 gone every Talos leg is a same-minor pair, so it duplicated 1cp-0w.
- Bump the leg documents, the default upgrade target in common.sh, and the e2e README's floor text to 1.14.

Cross-minor upgrade coverage ends with this change. Renovate PR #482 targeted the step this removes and can be closed.