### PR TITLE
feat(chart): add option to set revisionHistoryLimit

### DIFF
--- a/charts/tuppr/README.md
+++ b/charts/tuppr/README.md
@@ -94,6 +94,7 @@ Kubernetes: `>=1.25.0-0`
 | rbac.create | bool | `true` | Create the ClusterRole + ClusterRoleBinding the controller needs to manage nodes and jobs. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"metrics"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. |
 | replicaCount | int | `1` | Number of controller replicas (only one is active at a time via leader election). |
+| revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain for rollback. |
 | resources | object | `{}` | Pod resource requests/limits. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65532}` | Container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
 | service.port | int | `8080` | Service port for general access. |

--- a/charts/tuppr/README.md
+++ b/charts/tuppr/README.md
@@ -94,8 +94,8 @@ Kubernetes: `>=1.25.0-0`
 | rbac.create | bool | `true` | Create the ClusterRole + ClusterRoleBinding the controller needs to manage nodes and jobs. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"metrics"},"initialDelaySeconds":5,"periodSeconds":10}` | Readiness probe. |
 | replicaCount | int | `1` | Number of controller replicas (only one is active at a time via leader election). |
-| revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain for rollback. |
 | resources | object | `{}` | Pod resource requests/limits. |
+| revisionHistoryLimit | int | `10` | Number of old ReplicaSets to retain for rollback. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65532}` | Container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities). |
 | service.port | int | `8080` | Service port for general access. |
 | service.type | string | `"ClusterIP"` | Service type. |

--- a/charts/tuppr/templates/deployment.tpl
+++ b/charts/tuppr/templates/deployment.tpl
@@ -18,6 +18,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "tuppr.selectorLabels" . | nindent 6 }}

--- a/charts/tuppr/tests/deployment_test.yaml
+++ b/charts/tuppr/tests/deployment_test.yaml
@@ -54,6 +54,14 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: should set the revision history limit from values
+    set:
+      revisionHistoryLimit: 5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
   - it: should set security context
     asserts:
       - equal:

--- a/charts/tuppr/values.schema.json
+++ b/charts/tuppr/values.schema.json
@@ -512,6 +512,7 @@
     "revisionHistoryLimit": {
       "default": 10,
       "description": "Number of old ReplicaSets to retain for rollback.",
+      "minimum": 0,
       "title": "revisionHistoryLimit",
       "type": "integer"
     },

--- a/charts/tuppr/values.schema.json
+++ b/charts/tuppr/values.schema.json
@@ -509,6 +509,12 @@
       "title": "replicaCount",
       "type": "integer"
     },
+    "revisionHistoryLimit": {
+      "default": 10,
+      "description": "Number of old ReplicaSets to retain for rollback.",
+      "title": "revisionHistoryLimit",
+      "type": "integer"
+    },
     "resources": {
       "description": "Pod resource requests/limits.",
       "required": [],

--- a/charts/tuppr/values.schema.json
+++ b/charts/tuppr/values.schema.json
@@ -509,18 +509,17 @@
       "title": "replicaCount",
       "type": "integer"
     },
-    "revisionHistoryLimit": {
-      "default": 10,
-      "description": "Number of old ReplicaSets to retain for rollback.",
-      "minimum": 0,
-      "title": "revisionHistoryLimit",
-      "type": "integer"
-    },
     "resources": {
       "description": "Pod resource requests/limits.",
       "required": [],
       "title": "resources",
       "type": "object"
+    },
+    "revisionHistoryLimit": {
+      "default": 10,
+      "description": "Number of old ReplicaSets to retain for rollback.",
+      "title": "revisionHistoryLimit",
+      "type": "integer"
     },
     "securityContext": {
       "description": "Container securityContext (no privilege escalation, read-only root filesystem, drops ALL capabilities).",

--- a/charts/tuppr/values.yaml
+++ b/charts/tuppr/values.yaml
@@ -4,6 +4,9 @@
 # -- Number of controller replicas (only one is active at a time via leader election).
 replicaCount: 1
 
+# -- Number of old ReplicaSets to retain for rollback.
+revisionHistoryLimit: 10
+
 image:
   # -- Image repository.
   repository: ghcr.io/home-operations/tuppr


### PR DESCRIPTION
## Overview

Adds the option to set revisionHistoryLimit for the deployment in the Helm chart. This is useful in GitOps environments where rollbacks should always be done via Git, thus making the revision history useless.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
